### PR TITLE
Add coverage badge to README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,4 +41,4 @@ testdata/
 
 # Development files
 Makefile
-*.log 
+*.log

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion": 1, "label": "coverage", "message": "3.2%", "color": "red"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     
     - name: Run tests
       run: go test ./... -v
-    
+
     - name: Build binary
       run: go build -o bin/tgifreezeday ./cmd/tgifreezeday
     

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,90 @@
+name: Coverage Badge
+
+on:
+  push:
+    branches-ignore: [ 'main' ]
+
+env:
+  GO_VERSION: '1.24'
+
+jobs:
+  coverage:
+    name: Generate Coverage Badge
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    
+    - name: Download dependencies
+      run: go mod download
+    
+    - name: Run tests with coverage
+      run: go test ./... -coverprofile=coverage.out -covermode=atomic -v
+    
+    - name: Generate coverage badge
+      run: |
+        COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+        echo "Coverage: $COVERAGE%"
+        
+        # Set color based on coverage percentage
+        COVERAGE_NUM=$(echo $COVERAGE | cut -d'.' -f1)
+        if [ "$COVERAGE_NUM" -ge 80 ]; then
+          COLOR="brightgreen"
+        elif [ "$COVERAGE_NUM" -ge 60 ]; then
+          COLOR="green" 
+        elif [ "$COVERAGE_NUM" -ge 40 ]; then
+          COLOR="yellow"
+        elif [ "$COVERAGE_NUM" -ge 20 ]; then
+          COLOR="orange"
+        else
+          COLOR="red"
+        fi
+        
+        # Create a JSON file for shields.io endpoint
+        mkdir -p .github/badges
+        NEW_BADGE="{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"$COVERAGE%\", \"color\": \"$COLOR\"}"
+        echo "$NEW_BADGE" > .github/badges/coverage.json.new
+        
+        # Check if coverage has changed
+        if [ -f .github/badges/coverage.json ]; then
+          if cmp -s .github/badges/coverage.json .github/badges/coverage.json.new; then
+            echo "Coverage unchanged, skipping commit"
+            rm .github/badges/coverage.json.new
+            exit 0
+          fi
+        fi
+        
+        # Move new file to replace old one
+        mv .github/badges/coverage.json.new .github/badges/coverage.json
+        echo "Coverage updated to $COVERAGE%"
+        
+    - name: Commit coverage badge
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .github/badges/coverage.json
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "Update coverage badge [skip ci]"
+          git push
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.env
 secrets/
 bin/
+
+# Coverage files
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,25 @@ build:
 clean:
 	@echo "Cleaning..."
 	rm -rf $(BIN_DIR)
-	@echo "Cleaned $(BIN_DIR)"
+	rm -f coverage.out coverage.html
+	@echo "Cleaned $(BIN_DIR) and coverage files"
 
 # Run tests
 .PHONY: test
 test:
 	@echo "Running tests..."
 	go test ./... -v
+
+# Run tests with coverage
+.PHONY: coverage
+coverage:
+	@echo "Running tests with coverage..."
+	go test ./... -coverprofile=coverage.out -covermode=atomic -v
+	@echo ""
+	@echo "Coverage report:"
+	go tool cover -func=coverage.out
+	@echo ""
+	@echo "To view HTML coverage report, run: go tool cover -html=coverage.out"
 
 # Run the application
 .PHONY: run
@@ -66,6 +78,7 @@ help:
 	@echo "  build         - Build the application to $(BIN_DIR)/"
 	@echo "  clean         - Remove build artifacts"
 	@echo "  test          - Run tests"
+	@echo "  coverage      - Run tests with coverage and show report"
 	@echo "  run           - Build and run the application (use ARGS=\"subcommand\" to pass arguments)"
 	@echo "  sync          - Build and run sync command"
 	@echo "  wipe-blockers - Build and run wipe-blockers command"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # TGI Freeze Day
 
-[![CI/CD Pipeline](https://github.com/nvat/tgifreezeday/actions/workflows/ci.yml/badge.svg)](https://github.com/nvat/tgifreezeday/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nvat/tgifreezeday/main/.github/badges/coverage.json)](https://github.com/nvat/tgifreezeday/actions/workflows/coverage.yml)
 
 <img src="./docs/tgifreezeday.png">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TGI Freeze Day
 
+[![CI/CD Pipeline](https://github.com/nvat/tgifreezeday/actions/workflows/ci.yml/badge.svg)](https://github.com/nvat/tgifreezeday/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nvat/tgifreezeday/main/.github/badges/coverage.json)](https://github.com/nvat/tgifreezeday/actions/workflows/coverage.yml)
+
 <img src="./docs/tgifreezeday.png">
 
 A Go application that helps announce production freeze days to ensure safe deployments by:


### PR DESCRIPTION
This pull request introduces a comprehensive setup for tracking and displaying test coverage in the project, along with updates to the `Makefile` and `README.md` to integrate this functionality. The most important changes include adding a GitHub Actions workflow to generate a coverage badge, modifying the `Makefile` to support coverage-related tasks, and updating the `README.md` to display the coverage badge.

### Coverage tracking and badge generation:

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R1-R90): Added a new GitHub Actions workflow to calculate test coverage, generate a badge based on the coverage percentage, and update the badge file in the repository. The workflow includes steps for running tests, calculating coverage, and committing changes if the badge is updated.
* [`.github/badges/coverage.json`](diffhunk://#diff-3403143b0546f413dc5f19d4ba0e14e36730c4f5fec5b9e7a5a22cbcb2351e55R1): Added a JSON file to store the coverage badge data for integration with Shields.io.

### Makefile enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L23-R42): Added a `coverage` target to run tests with coverage, generate a coverage report, and provide instructions for viewing an HTML report. Updated the `clean` target to remove coverage-related files.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R81): Updated the `help` target to include a description of the new `coverage` target.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R5): Added badges for CI/CD pipeline status and test coverage to the top of the README for better visibility of project health metrics.