### PR TITLE
CI: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ '*' ]
+  workflow_dispatch:
 
 env:
   GO_VERSION: '1.25'


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to the CI trigger so the pipeline can be manually re-run from the GitHub Actions UI

## Why this is needed now

PR #7 was merged as a squash commit whose body included:

```
* Update coverage badge [skip ci]
```

GitHub scans the **entire** commit message body for `[skip ci]` and skipped CI on the resulting main push — that's why no run appeared after the merge.

Merging this PR pushes a clean commit to main (no `[skip ci]` in the message), which will re-trigger the full pipeline and unblock the Docker image push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)