### PR TITLE
Fix Dockerfile: upgrade base image golang:1.24 → golang:1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Bump the builder stage from `golang:1.24-alpine` to `golang:1.25-alpine`

## Why

`go.mod` requires `go >= 1.25.0`. The 1.24 image ships with go1.24.13 and `GOTOOLCHAIN=local` is set, so it refuses to build the project:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

This caused the Docker job to fail at `RUN go mod download` (step 5/7 of the builder stage) in CI run [25476606410](https://github.com/nvatuan/tgifreezeday/actions/runs/25476606410).

🤖 Generated with [Claude Code](https://claude.com/claude-code)