### PR TITLE
fix: address code review findings on auto-sync (PR #14)

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "9.3%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "9.9%", "color": "red"}

--- a/internal/adapter/db/config.go
+++ b/internal/adapter/db/config.go
@@ -53,9 +53,7 @@ const configSelectCols = `id, user_id, name, schema_version, config_yaml,
 	status, status_message, created_at, updated_at,
 	sync_schedule, next_sync_at, last_auto_synced_at, last_auto_sync_result`
 
-func scanConfig(row interface {
-	Scan(dest ...any) error
-}) (*Config, error) {
+func scanConfig(row interface{ Scan(dest ...any) error }) (*Config, error) {
 	c := &Config{}
 	var nextSyncAt sql.NullTime
 	var lastAutoSyncedAt sql.NullTime
@@ -220,7 +218,10 @@ func (s *ConfigStore) Delete(id, userID int64) error {
 // UpdateNextSyncAt advances next_sync_at without touching other fields.
 func (s *ConfigStore) UpdateNextSyncAt(id int64, nextSyncAt time.Time) error {
 	_, err := s.db.Exec(`UPDATE configs SET next_sync_at = ? WHERE id = ?`, nextSyncAt, id)
-	return err
+	if err != nil {
+		return fmt.Errorf("update next_sync_at: %w", err)
+	}
+	return nil
 }
 
 // ListDueForAutoSync returns configs whose auto-sync schedule is due (next_sync_at <= now).

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,25 +12,28 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// jst is the fixed UTC+9 timezone used for all schedule calculations.
-var jst = time.FixedZone("JST", 9*60*60)
+// JST is the fixed UTC+9 timezone used for all schedule calculations.
+// Exported so callers (e.g. the UI layer) can format timestamps consistently
+// without duplicating the timezone definition.
+// JST has no DST, so +24h arithmetic is always safe here.
+var JST = time.FixedZone("JST", 9*60*60)
 
 // NextSyncAt returns the next scheduled time strictly after `from` for the given schedule.
 // weekly  → every Monday 09:00 JST
 // monthly → 1st of every month 09:00 JST
 func NextSyncAt(schedule string, from time.Time) time.Time {
-	fromJST := from.In(jst)
+	fromJST := from.In(JST)
 	switch schedule {
 	case db.SyncScheduleWeekly:
-		target := time.Date(fromJST.Year(), fromJST.Month(), fromJST.Day(), 9, 0, 0, 0, jst)
+		target := time.Date(fromJST.Year(), fromJST.Month(), fromJST.Day(), 9, 0, 0, 0, JST)
 		for target.Weekday() != time.Monday || !target.After(from) {
 			target = target.Add(24 * time.Hour)
 		}
 		return target.UTC()
 	case db.SyncScheduleMonthly:
-		target := time.Date(fromJST.Year(), fromJST.Month(), 1, 9, 0, 0, 0, jst)
+		target := time.Date(fromJST.Year(), fromJST.Month(), 1, 9, 0, 0, 0, JST)
 		for !target.After(from) {
-			target = time.Date(target.Year(), target.Month()+1, 1, 9, 0, 0, 0, jst)
+			target = time.Date(target.Year(), target.Month()+1, 1, 9, 0, 0, 0, JST)
 		}
 		return target.UTC()
 	default:
@@ -99,9 +102,13 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) {
 
 func (s *Scheduler) syncConfig(ctx context.Context, cfg *db.Config) {
 	log := logging.GetLogger().WithField("config_id", cfg.ID)
-	syncedAt := time.Now().UTC()
 
 	msg, isErr := s.runSync(ctx, cfg)
+	// Capture time AFTER runSync so next_sync_at is computed from the actual
+	// completion time, not the start time (avoids re-firing immediately when sync
+	// takes long enough to straddle a schedule boundary).
+	syncedAt := time.Now().UTC()
+
 	prefix := "✅ "
 	if isErr {
 		prefix = "❌ "

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func jstTime(year int, month time.Month, day, hour, min int) time.Time {
-	return time.Date(year, month, day, hour, min, 0, 0, jst)
+	return time.Date(year, month, day, hour, min, 0, 0, JST)
 }
 
 func TestNextSyncAt_Weekly(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNextSyncAt_Weekly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NextSyncAt("weekly", tc.from)
 			if !got.Equal(tc.want.UTC()) {
-				t.Errorf("NextSyncAt(weekly, %v) = %v, want %v", tc.from, got.In(jst), tc.want.In(jst))
+				t.Errorf("NextSyncAt(weekly, %v) = %v, want %v", tc.from, got.In(JST), tc.want.In(JST))
 			}
 			if !got.After(tc.from) {
 				t.Errorf("result %v is not strictly after from %v", got, tc.from)
@@ -90,7 +90,7 @@ func TestNextSyncAt_Monthly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NextSyncAt("monthly", tc.from)
 			if !got.Equal(tc.want.UTC()) {
-				t.Errorf("NextSyncAt(monthly, %v) = %v, want %v", tc.from, got.In(jst), tc.want.In(jst))
+				t.Errorf("NextSyncAt(monthly, %v) = %v, want %v", tc.from, got.In(JST), tc.want.In(JST))
 			}
 			if !got.After(tc.from) {
 				t.Errorf("result %v is not strictly after from %v", got, tc.from)

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -23,8 +23,8 @@ import (
 
 var log = logging.GetLogger()
 
-// jstDisplay is used for formatting timestamps in the UI.
-var jstDisplay = time.FixedZone("JST", 9*60*60)
+// jstDisplay aliases scheduler.JST for formatting timestamps in the UI.
+var jstDisplay = scheduler.JST
 
 type ConfigHandler struct {
 	configs     *db.ConfigStore
@@ -508,6 +508,8 @@ func (h *ConfigHandler) listBlockers(ctx context.Context, userID int64, cfg *db.
 
 // --- schedule helpers ---
 
+// parseSyncSchedule normalises the form value. Any unrecognised value (including
+// wrong-case variants) is silently treated as "none" — form tampering is harmless here.
 func parseSyncSchedule(s string) string {
 	switch s {
 	case db.SyncScheduleWeekly, db.SyncScheduleMonthly:


### PR DESCRIPTION
## What & Why

Follow-up fixes for the code review on PR #14 (`feat/auto-sync`).

## Changes

### 🐛 Bug fix
- **`syncedAt` captured after `runSync` returns** (`scheduler/scheduler.go`).  
  Previously `syncedAt = time.Now()` was set *before* the sync ran, so `NextSyncAt(schedule, syncedAt)` could compute a `next_sync_at` in the past if the sync took long enough to straddle a schedule boundary (e.g., sync started Monday 08:59 JST and finished at 09:01). The config would then be picked up again on the very next tick.

### 🧹 Cleanup
- **Export `scheduler.JST`** and reuse it in the handler layer — removes the duplicate `time.FixedZone("JST", …)` definition.
- **JST no-DST comment** added to `NextSyncAt` explaining why `+24h` day arithmetic is always safe.
- **`UpdateNextSyncAt` error wrapping** — now uses `fmt.Errorf("update next_sync_at: %w", err)` consistent with all other DB methods.
- **`parseSyncSchedule` comment** — documents the intentional silent coercion of unknown values to `"none"`.
- **`scanConfig` interface literal** tightened (`interface{ … }` inline).

## Test plan
- [ ] `go test ./...` passes
- [ ] Verify scheduler logs show correct `next_sync_at` after a sync that takes > 1 second

🤖 Generated with [Claude Code](https://claude.com/claude-code)