### PR TITLE
fix: address PR #14 review comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ HTTPS_ONLY=false   # set to true in production to add Secure flag to session/OAu
 # Access control — comma-separated email lists (empty = everyone is read-only by default)
 POWER_USER_EMAIL_LIST=admin@example.com           # full access: create/edit/delete any config
 WRITE_USER_EMAIL_LIST=dev@example.com,ops@example.com  # create + manage own configs
+
+SCHED_TICKER_FREQUENCY_MIN=15 # how often schedule run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,18 @@ You will be a coding agent for me. Read the README.md and CONTRIBUTE.md to start
 - Always start from latest default branch, checkout to another branch.
 - Remember to work on a separate git worktree
 - Implement a feature first by writing test, then code from start to end such that the test succeeds, then run format or lint, finally test running the app locally.
+
+```bash
+golangci-lint run ./...
+gofmt -l .
+go test ./... -v
+```
+
 - Then, you create a PR on git remote origin
 - Then, start a subagent review the PR you create
 - Resolve the subagent feedbacks, making sure format lint and unit tests passing.
 - At last step, let me know when the PR is ready.
+- When adding new envvar, write validate code and update .env.sample
 
 ## Principle
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -69,7 +70,12 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sched := scheduler.New(configs, tokens, oauthCfg)
+	schedTickerMin := 15
+	if v, err := strconv.Atoi(os.Getenv("SCHED_TICKER_FREQUENCY_MIN")); err == nil && v > 0 {
+		schedTickerMin = v
+	}
+
+	sched := scheduler.New(configs, tokens, oauthCfg, schedTickerMin)
 	go sched.Start(ctx)
 
 	authH := handler.NewAuthHandler(users, tokens, secret, httpsOnly, oauthCfg, basePath)

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -5,6 +5,7 @@ import (
 )
 
 type TGIFCalendarRepository interface {
-	GetFreezeDaysInRange(dateAnchor time.Time) (*TGIFMapping, error)
+	GetFreezeDaysInRange(rangeStart, rangeEnd time.Time) (*TGIFMapping, error)
+	WipeAllBlockersInRange(startDate, endDate time.Time) error
 	WriteBlockerOnDate(date time.Time, summary, description string) error
 }

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -1,0 +1,35 @@
+package domain
+
+import (
+	"fmt"
+	"time"
+)
+
+// RunSync wipes all managed blocker events in [rangeStart, rangeEnd] and rewrites
+// them based on the freeze-day rules. It is the shared business logic for both
+// manual sync (HTTP handler) and scheduled auto-sync (background worker).
+// Returns a human-readable result message and whether it was an error.
+func RunSync(
+	repo TGIFCalendarRepository,
+	rangeStart, rangeEnd time.Time,
+	rules TodayIsFreezeDayIf,
+	summary, description string,
+) (string, bool) {
+	tgifMapping, err := repo.GetFreezeDaysInRange(rangeStart, rangeEnd)
+	if err != nil {
+		return "failed to get freeze days: " + err.Error(), true
+	}
+	if err := repo.WipeAllBlockersInRange(rangeStart, rangeEnd); err != nil {
+		return "failed to wipe existing blockers: " + err.Error(), true
+	}
+	count := 0
+	for _, day := range *tgifMapping {
+		if day.IsTodayFreezeDay(rules) {
+			if err := repo.WriteBlockerOnDate(day.Date, summary, description); err != nil {
+				return fmt.Sprintf("failed to write blocker on %s: %s", day.Date.Format("2006-01-02"), err.Error()), true
+			}
+			count++
+		}
+	}
+	return fmt.Sprintf("Sync complete. Created %d blocker event(s) across %d days checked.", count, len(*tgifMapping)), false
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nvat/tgifreezeday/internal/adapter/db"
 	"github.com/nvat/tgifreezeday/internal/adapter/googlecalendar"
 	appconfig "github.com/nvat/tgifreezeday/internal/config"
+	"github.com/nvat/tgifreezeday/internal/domain"
 	"github.com/nvat/tgifreezeday/internal/logging"
 	"golang.org/x/oauth2"
 )
@@ -42,24 +43,34 @@ func NextSyncAt(schedule string, from time.Time) time.Time {
 }
 
 type Scheduler struct {
-	configs  *db.ConfigStore
-	tokens   *db.TokenStore
-	oauthCfg *oauth2.Config
+	configs       *db.ConfigStore
+	tokens        *db.TokenStore
+	oauthCfg      *oauth2.Config
+	tickerMinutes int
 }
 
-func New(configs *db.ConfigStore, tokens *db.TokenStore, oauthCfg *oauth2.Config) *Scheduler {
-	return &Scheduler{configs: configs, tokens: tokens, oauthCfg: oauthCfg}
+// New creates a Scheduler. tickerMinutes controls how often the scheduler polls
+// for due configs; set via SCHED_TICKER_FREQUENCY_MIN (default 15, must be > 0).
+func New(configs *db.ConfigStore, tokens *db.TokenStore, oauthCfg *oauth2.Config, tickerMinutes int) *Scheduler {
+	return &Scheduler{
+		configs:       configs,
+		tokens:        tokens,
+		oauthCfg:      oauthCfg,
+		tickerMinutes: tickerMinutes,
+	}
 }
 
 // Start runs the scheduler loop. It advances any past-due configs on startup,
-// then processes due configs every minute. Blocks until ctx is cancelled.
+// then polls for due configs on the configured interval. Blocks until ctx is cancelled.
 func (s *Scheduler) Start(ctx context.Context) {
 	log := logging.GetLogger()
+	log.WithField("ticker_minutes", s.tickerMinutes).Info("scheduler: starting")
+
 	if err := s.advancePastDue(); err != nil {
 		log.WithError(err).Warn("scheduler: failed to advance past-due configs on startup")
 	}
 
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(time.Duration(s.tickerMinutes) * time.Minute)
 	defer ticker.Stop()
 	for {
 		select {
@@ -90,9 +101,12 @@ func (s *Scheduler) advancePastDue() error {
 }
 
 func (s *Scheduler) tick(ctx context.Context, now time.Time) {
+	log := logging.GetLogger()
+	log.WithField("time", now.UTC().Format(time.RFC3339)).Debug("scheduler: tick")
+
 	due, err := s.configs.ListDueForAutoSync(now.UTC())
 	if err != nil {
-		logging.GetLogger().WithError(err).Error("scheduler: failed to query due configs")
+		log.WithError(err).Error("scheduler: failed to query due configs")
 		return
 	}
 	for _, cfg := range due {
@@ -142,25 +156,13 @@ func (s *Scheduler) runSync(ctx context.Context, cfg *db.Config) (string, bool) 
 		return err.Error(), true
 	}
 	rangeStart, rangeEnd := syncDateRange(appCfg.Shared.LookbackDays, appCfg.Shared.LookaheadDays)
-	tgifMapping, err := repo.GetFreezeDaysInRange(rangeStart, rangeEnd)
-	if err != nil {
-		return "failed to get freeze days: " + err.Error(), true
-	}
-	if err := repo.WipeAllBlockersInRange(rangeStart, rangeEnd); err != nil {
-		return "failed to wipe existing blockers: " + err.Error(), true
-	}
-	summary := *appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary
-	description := *appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description
-	count := 0
-	for _, day := range *tgifMapping {
-		if day.IsTodayFreezeDay(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf) {
-			if err := repo.WriteBlockerOnDate(day.Date, summary, description); err != nil {
-				return fmt.Sprintf("failed to write blocker on %s: %s", day.Date.Format("2006-01-02"), err.Error()), true
-			}
-			count++
-		}
-	}
-	return fmt.Sprintf("Sync complete. Created %d blocker event(s) across %d days checked.", count, len(*tgifMapping)), false
+	return domain.RunSync(
+		repo,
+		rangeStart, rangeEnd,
+		domain.TodayIsFreezeDayIf(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf),
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary,
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description,
+	)
 }
 
 func parseAppConfig(yamlContent string) (*appconfig.Config, error) {

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nvat/tgifreezeday/internal/adapter/db"
 	"github.com/nvat/tgifreezeday/internal/adapter/googlecalendar"
 	appconfig "github.com/nvat/tgifreezeday/internal/config"
+	"github.com/nvat/tgifreezeday/internal/domain"
 	"github.com/nvat/tgifreezeday/internal/logging"
 	"github.com/nvat/tgifreezeday/internal/perm"
 	"github.com/nvat/tgifreezeday/internal/scheduler"
@@ -419,25 +420,13 @@ func (h *ConfigHandler) runSync(ctx context.Context, userID int64, cfg *db.Confi
 		return err.Error(), true
 	}
 	rangeStart, rangeEnd := dateRange(appCfg.Shared.LookbackDays, appCfg.Shared.LookaheadDays)
-	tgifMapping, err := repo.GetFreezeDaysInRange(rangeStart, rangeEnd)
-	if err != nil {
-		return "failed to get freeze days: " + err.Error(), true
-	}
-	if err := repo.WipeAllBlockersInRange(rangeStart, rangeEnd); err != nil {
-		return "failed to wipe existing blockers: " + err.Error(), true
-	}
-	summary := *appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary
-	description := *appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description
-	count := 0
-	for _, day := range *tgifMapping {
-		if day.IsTodayFreezeDay(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf) {
-			if err := repo.WriteBlockerOnDate(day.Date, summary, description); err != nil {
-				return fmt.Sprintf("failed to write blocker on %s: %s", day.Date.Format("2006-01-02"), err.Error()), true
-			}
-			count++
-		}
-	}
-	return fmt.Sprintf("Sync complete. Created %d blocker event(s) across %d days checked.", count, len(*tgifMapping)), false
+	return domain.RunSync(
+		repo,
+		rangeStart, rangeEnd,
+		domain.TodayIsFreezeDayIf(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf),
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary,
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description,
+	)
 }
 
 func (h *ConfigHandler) runWipe(ctx context.Context, userID int64, cfg *db.Config) (string, bool) {


### PR DESCRIPTION
## Summary

Addresses the 4 actionable comments left on PR #14. Comment #3 (advancePastDue behaviour) is noted as a separate discussion.

- **#5 — Duplicated sync logic**: extracted core wipe-and-rewrite loop into `domain.RunSync(repo, rangeStart, rangeEnd, rules, summary, description)`. Handler and scheduler now both call it. Also updated `TGIFCalendarRepository` interface to fix the stale `GetFreezeDaysInRange` signature and add the missing `WipeAllBlockersInRange`.
- **#2 — Ticker too frequent / configurable**: default changed to 15 min. Set `SCHED_TICKER_FREQUENCY_MIN=<n>` (positive integer) to override. Invalid/missing values silently fall back to 15.
- **#1 — Missing startup log**: `scheduler.Start` now logs `INFO scheduler: starting ticker_minutes=N`.
- **#4 — Missing tick debug log**: each tick logs `DEBUG scheduler: tick time=...`.

## Test plan
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `gofmt -l .` — no output
- [ ] Set `SCHED_TICKER_FREQUENCY_MIN=1` and verify logs show 1-min ticks
- [ ] Unset env var, verify default 15-min interval in startup log

🤖 Generated with [Claude Code](https://claude.com/claude-code)