### PR TITLE
fix: run past-due syncs on startup instead of skipping them

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "9.9%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "10.0%", "color": "red"}

--- a/internal/adapter/db/config.go
+++ b/internal/adapter/db/config.go
@@ -215,15 +215,6 @@ func (s *ConfigStore) Delete(id, userID int64) error {
 	return err
 }
 
-// UpdateNextSyncAt advances next_sync_at without touching other fields.
-func (s *ConfigStore) UpdateNextSyncAt(id int64, nextSyncAt time.Time) error {
-	_, err := s.db.Exec(`UPDATE configs SET next_sync_at = ? WHERE id = ?`, nextSyncAt, id)
-	if err != nil {
-		return fmt.Errorf("update next_sync_at: %w", err)
-	}
-	return nil
-}
-
 // ListDueForAutoSync returns configs whose auto-sync schedule is due (next_sync_at <= now).
 func (s *ConfigStore) ListDueForAutoSync(now time.Time) ([]*Config, error) {
 	rows, err := s.db.Query(`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -60,15 +60,12 @@ func New(configs *db.ConfigStore, tokens *db.TokenStore, oauthCfg *oauth2.Config
 	}
 }
 
-// Start runs the scheduler loop. It advances any past-due configs on startup,
-// then polls for due configs on the configured interval. Blocks until ctx is cancelled.
+// Start runs the scheduler loop. On startup any configs whose next_sync_at is
+// already in the past are picked up on the first tick and synced immediately.
+// Blocks until ctx is cancelled.
 func (s *Scheduler) Start(ctx context.Context) {
 	log := logging.GetLogger()
 	log.WithField("ticker_minutes", s.tickerMinutes).Info("scheduler: starting")
-
-	if err := s.advancePastDue(); err != nil {
-		log.WithError(err).Warn("scheduler: failed to advance past-due configs on startup")
-	}
 
 	ticker := time.NewTicker(time.Duration(s.tickerMinutes) * time.Minute)
 	defer ticker.Stop()
@@ -80,24 +77,6 @@ func (s *Scheduler) Start(ctx context.Context) {
 			s.tick(ctx, t)
 		}
 	}
-}
-
-// advancePastDue moves next_sync_at forward for any configs that are overdue at startup,
-// implementing the "missed windows are silently skipped" behaviour.
-func (s *Scheduler) advancePastDue() error {
-	now := time.Now().UTC()
-	due, err := s.configs.ListDueForAutoSync(now)
-	if err != nil {
-		return err
-	}
-	log := logging.GetLogger()
-	for _, cfg := range due {
-		next := NextSyncAt(cfg.SyncSchedule, now)
-		if err := s.configs.UpdateNextSyncAt(cfg.ID, next); err != nil {
-			log.WithError(err).WithField("config_id", cfg.ID).Warn("scheduler: failed to advance past-due config")
-		}
-	}
-	return nil
 }
 
 func (s *Scheduler) tick(ctx context.Context, now time.Time) {


### PR DESCRIPTION
## Summary

Resolves comment #3 on PR #14.

Removes `advancePastDue` and `UpdateNextSyncAt`. The previous behaviour silently skipped any sync windows that were missed during server downtime. The correct behaviour is to run them: `ListDueForAutoSync` already returns configs with `next_sync_at <= now`, so past-due configs are naturally picked up on the first ticker tick after restart — no special startup logic needed.

**Before:** server restarts after downtime → missed Monday sync is skipped, waits until next Monday.  
**After:** server restarts after downtime → missed Monday sync runs on the next tick (within `SCHED_TICKER_FREQUENCY_MIN` minutes).

Since `RunSync` always operates on the current date range (today ± lookback/lookahead), running a "missed" sync produces the same result as a fresh sync — it's just delayed, not lost.

## Test plan
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] Set a config to weekly, stop server before Monday 09:00 JST, restart after — verify sync runs within one tick rather than waiting until next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)