### PR TITLE
feat: clickable Auto-Sync on detail page + auto-sync badge on dashboard

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "10.0%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "9.7%", "color": "red"}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,6 +114,7 @@ func main() {
 	mux.Handle("POST "+basePath+"/configs/{id}/validate", requireAuth(http.HandlerFunc(cfgH.HandleValidate)))
 	mux.Handle("POST "+basePath+"/configs/{id}/sync", requireAuth(http.HandlerFunc(cfgH.HandleSync)))
 	mux.Handle("POST "+basePath+"/configs/{id}/wipe", requireAuth(http.HandlerFunc(cfgH.HandleWipe)))
+	mux.Handle("POST "+basePath+"/configs/{id}/auto-sync", requireAuth(http.HandlerFunc(cfgH.HandleUpdateAutoSync)))
 	mux.Handle("GET "+basePath+"/configs/{id}/blockers", requireAuth(http.HandlerFunc(cfgH.HandleListBlockers)))
 
 	// Schema reference (public — no auth needed, no secrets exposed)

--- a/internal/adapter/db/config.go
+++ b/internal/adapter/db/config.go
@@ -203,6 +203,16 @@ func (s *ConfigStore) Update(id, userID int64, name, configYAML, syncSchedule st
 	return err
 }
 
+// UpdateSyncSchedule updates only the sync schedule fields without touching status or config YAML.
+func (s *ConfigStore) UpdateSyncSchedule(id, userID int64, schedule string, nextSyncAt *time.Time) error {
+	_, err := s.db.Exec(`
+		UPDATE configs
+		SET sync_schedule = ?, next_sync_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND user_id = ?
+	`, schedule, nextSyncAt, id, userID)
+	return err
+}
+
 func (s *ConfigStore) UpdateStatus(id int64, status ConfigStatus, message string) error {
 	_, err := s.db.Exec(`
 		UPDATE configs SET status = ?, status_message = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -712,7 +712,8 @@ func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
       Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
       When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
     </p>
-    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML">
+    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML"
+          hx-on::htmx:response-error="document.getElementById('autosync-modal-error').textContent='Save failed ('+event.detail.xhr.status+') — please try again'">
       <label for="modal-sync-schedule">Schedule
         <select id="modal-sync-schedule" name="sync_schedule">
           %s

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -321,6 +321,11 @@ func (h *ConfigHandler) HandleUpdateAutoSync(w http.ResponseWriter, r *http.Requ
 		httpError(w, http.StatusBadRequest, "invalid config id")
 		return
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<10) // 1 KB — only one small field
+	if err := r.ParseForm(); err != nil {
+		httpError(w, http.StatusBadRequest, "invalid form")
+		return
+	}
 	cfg, err := h.getConfig(r.Context(), id, user.ID)
 	if err != nil || cfg == nil {
 		httpError(w, http.StatusNotFound, "config not found")
@@ -330,14 +335,9 @@ func (h *ConfigHandler) HandleUpdateAutoSync(w http.ResponseWriter, r *http.Requ
 		httpError(w, http.StatusForbidden, "you do not have permission to edit this config")
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<10) // 1 KB — only one small field
-	if err := r.ParseForm(); err != nil {
-		httpError(w, http.StatusBadRequest, "invalid form")
-		return
-	}
 	newSchedule := parseSyncSchedule(r.FormValue("sync_schedule"))
 	nextSyncAt := computeNextSyncAt(cfg.SyncSchedule, cfg.NextSyncAt, newSchedule)
-	if err := h.configs.Update(id, cfg.UserID, cfg.Name, cfg.ConfigYAML, newSchedule, nextSyncAt); err != nil {
+	if err := h.configs.UpdateSyncSchedule(id, cfg.UserID, newSchedule, nextSyncAt); err != nil {
 		httpError(w, http.StatusInternalServerError, "failed to update auto-sync")
 		return
 	}
@@ -676,7 +676,7 @@ func autoSyncInfoHTML(cfg *db.Config) string {
 </div>`, html.EscapeString(scheduleLabel), lastSyncHTML, nextSyncHTML)
 }
 
-func autoSyncTriggerHTML(basePath string, cfg *db.Config, canEdit bool) string {
+func autoSyncTriggerHTML(cfg *db.Config, canEdit bool) string {
 	scheduleLabel := map[string]string{
 		db.SyncScheduleNone:    "off",
 		db.SyncScheduleWeekly:  "weekly",
@@ -686,18 +686,15 @@ func autoSyncTriggerHTML(basePath string, cfg *db.Config, canEdit bool) string {
 		scheduleLabel = "off"
 	}
 
-	style := "border-bottom:1px dotted currentColor;cursor:pointer;color:#60a5fa;background:none;border-top:none;border-left:none;border-right:none;padding:0;font-size:inherit;font-family:inherit"
+	escaped := html.EscapeString(scheduleLabel)
+	baseStyle := "border-bottom:1px dotted currentColor;color:#60a5fa;background:none;border-top:none;border-left:none;border-right:none;padding:0;font-size:inherit;font-family:inherit"
+
 	if !canEdit {
-		style = "border-bottom:1px dotted currentColor;cursor:default;color:#60a5fa;background:none;border-top:none;border-left:none;border-right:none;padding:0;font-size:inherit;font-family:inherit"
+		return fmt.Sprintf(` &nbsp;·&nbsp; Auto Sync: <span id="autosync-trigger"><span style="%s;cursor:default" title="Auto-Sync schedule">%s</span></span>`,
+			baseStyle, escaped)
 	}
-
-	onClick := ""
-	if canEdit {
-		onClick = `onclick="document.getElementById('autosync-modal').showModal()"`
-	}
-
-	return fmt.Sprintf(` &nbsp;·&nbsp; Auto Sync: <span id="autosync-trigger"><button type="button" style="%s" title="Configure Auto-Sync" %s>%s</button></span>`,
-		style, onClick, html.EscapeString(scheduleLabel))
+	return fmt.Sprintf(` &nbsp;·&nbsp; Auto Sync: <span id="autosync-trigger"><button type="button" style="%s;cursor:pointer" title="Configure Auto-Sync" onclick="document.getElementById('autosync-modal').showModal()">%s</button></span>`,
+		baseStyle, escaped)
 }
 
 func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
@@ -717,29 +714,20 @@ func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
       Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
       When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
     </p>
-    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="body" hx-swap="none">
+    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML">
       <label for="modal-sync-schedule">Schedule
         <select id="modal-sync-schedule" name="sync_schedule">
           %s
         </select>
       </label>
-      <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1.25rem">
+      <div id="autosync-modal-error" style="min-height:1.5rem;margin-top:0.5rem"></div>
+      <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
         <button type="button" class="outline secondary" onclick="document.getElementById('autosync-modal').close()">Cancel</button>
         <button type="submit">Save</button>
       </div>
     </form>
   </article>
-</dialog>
-<script>
-  document.addEventListener('htmx:afterRequest', function(evt) {
-    if (evt.detail.pathInfo && evt.detail.pathInfo.requestPath && evt.detail.pathInfo.requestPath.endsWith('/auto-sync')) {
-      if (evt.detail.xhr.status >= 200 && evt.detail.xhr.status < 300) {
-        var redirect = evt.detail.xhr.getResponseHeader('HX-Redirect');
-        if (redirect) { window.location.href = redirect; }
-      }
-    }
-  });
-</script>`,
+</dialog>`,
 		cfg.ID, syncScheduleOptions(cfg.SyncSchedule))
 }
 
@@ -806,7 +794,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 		syncActionsHTML = validateBtn + syncBtn + wipeBtn
 	}
 
-	autoSyncTrigger := autoSyncTriggerHTML(basePath, cfg, canEdit)
+	autoSyncTrigger := autoSyncTriggerHTML(cfg, canEdit)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -313,6 +313,38 @@ func (h *ConfigHandler) HandleWipe(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, actionResultHTML("Wipe", msg, isErr)) //nolint:errcheck
 }
 
+// HandleUpdateAutoSync updates only the sync_schedule for a config. Returns HX-Redirect to the detail page.
+func (h *ConfigHandler) HandleUpdateAutoSync(w http.ResponseWriter, r *http.Request) {
+	user := userFromContext(r.Context())
+	id, ok := idFromPath(r)
+	if !ok {
+		httpError(w, http.StatusBadRequest, "invalid config id")
+		return
+	}
+	cfg, err := h.getConfig(r.Context(), id, user.ID)
+	if err != nil || cfg == nil {
+		httpError(w, http.StatusNotFound, "config not found")
+		return
+	}
+	if role := roleFromContext(r.Context()); !role.CanEditConfig(cfg.UserID, user.ID) {
+		httpError(w, http.StatusForbidden, "you do not have permission to edit this config")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<10) // 1 KB — only one small field
+	if err := r.ParseForm(); err != nil {
+		httpError(w, http.StatusBadRequest, "invalid form")
+		return
+	}
+	newSchedule := parseSyncSchedule(r.FormValue("sync_schedule"))
+	nextSyncAt := computeNextSyncAt(cfg.SyncSchedule, cfg.NextSyncAt, newSchedule)
+	if err := h.configs.Update(id, cfg.UserID, cfg.Name, cfg.ConfigYAML, newSchedule, nextSyncAt); err != nil {
+		httpError(w, http.StatusInternalServerError, "failed to update auto-sync")
+		return
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf(h.basePath+"/configs/%d", id))
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // HandleListBlockers returns a blockers table partial (HTMX).
 func (h *ConfigHandler) HandleListBlockers(w http.ResponseWriter, r *http.Request) {
 	user := userFromContext(r.Context())
@@ -644,6 +676,73 @@ func autoSyncInfoHTML(cfg *db.Config) string {
 </div>`, html.EscapeString(scheduleLabel), lastSyncHTML, nextSyncHTML)
 }
 
+func autoSyncTriggerHTML(basePath string, cfg *db.Config, canEdit bool) string {
+	scheduleLabel := map[string]string{
+		db.SyncScheduleNone:    "off",
+		db.SyncScheduleWeekly:  "weekly",
+		db.SyncScheduleMonthly: "monthly",
+	}[cfg.SyncSchedule]
+	if scheduleLabel == "" {
+		scheduleLabel = "off"
+	}
+
+	style := "border-bottom:1px dotted currentColor;cursor:pointer;color:#60a5fa;background:none;border-top:none;border-left:none;border-right:none;padding:0;font-size:inherit;font-family:inherit"
+	if !canEdit {
+		style = "border-bottom:1px dotted currentColor;cursor:default;color:#60a5fa;background:none;border-top:none;border-left:none;border-right:none;padding:0;font-size:inherit;font-family:inherit"
+	}
+
+	onClick := ""
+	if canEdit {
+		onClick = `onclick="document.getElementById('autosync-modal').showModal()"`
+	}
+
+	return fmt.Sprintf(` &nbsp;·&nbsp; Auto Sync: <span id="autosync-trigger"><button type="button" style="%s" title="Configure Auto-Sync" %s>%s</button></span>`,
+		style, onClick, html.EscapeString(scheduleLabel))
+}
+
+func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
+	if !canEdit {
+		return ""
+	}
+	return fmt.Sprintf(`
+<dialog id="autosync-modal" style="max-width:480px;width:100%%;border-radius:0.75rem;padding:2rem;background:var(--pico-card-background-color);border:1px solid var(--pico-card-border-color);color:var(--pico-color)">
+  <article style="margin:0;padding:0;border:none;background:none">
+    <header style="margin-bottom:1rem;padding:0;border:none">
+      <div style="display:flex;align-items:center;justify-content:space-between">
+        <strong style="font-size:1.1rem">⏰ Auto-Sync</strong>
+        <button type="button" onclick="document.getElementById('autosync-modal').close()" style="background:none;border:none;cursor:pointer;font-size:1.3rem;color:var(--pico-muted-color);padding:0;line-height:1">×</button>
+      </div>
+    </header>
+    <p style="font-size:0.88rem;color:var(--pico-muted-color);margin-bottom:1.25rem">
+      Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
+      When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
+    </p>
+    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="body" hx-swap="none">
+      <label for="modal-sync-schedule">Schedule
+        <select id="modal-sync-schedule" name="sync_schedule">
+          %s
+        </select>
+      </label>
+      <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1.25rem">
+        <button type="button" class="outline secondary" onclick="document.getElementById('autosync-modal').close()">Cancel</button>
+        <button type="submit">Save</button>
+      </div>
+    </form>
+  </article>
+</dialog>
+<script>
+  document.addEventListener('htmx:afterRequest', function(evt) {
+    if (evt.detail.pathInfo && evt.detail.pathInfo.requestPath && evt.detail.pathInfo.requestPath.endsWith('/auto-sync')) {
+      if (evt.detail.xhr.status >= 200 && evt.detail.xhr.status < 300) {
+        var redirect = evt.detail.xhr.getResponseHeader('HX-Redirect');
+        if (redirect) { window.location.href = redirect; }
+      }
+    }
+  });
+</script>`,
+		cfg.ID, syncScheduleOptions(cfg.SyncSchedule))
+}
+
 func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role perm.Role) string {
 	badge := statusBadgeHTML(cfg.Status, cfg.StatusMessage)
 	escapedName := html.EscapeString(cfg.Name)
@@ -707,11 +806,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 		syncActionsHTML = validateBtn + syncBtn + wipeBtn
 	}
 
-	autoSyncBadge := ""
-	if autoSyncEnabled {
-		autoSyncBadge = fmt.Sprintf(` &nbsp;·&nbsp; <strong style="color:#60a5fa">⏰ auto-sync: %s</strong>`,
-			html.EscapeString(cfg.SyncSchedule))
-	}
+	autoSyncTrigger := autoSyncTriggerHTML(basePath, cfg, canEdit)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -812,15 +907,18 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 
   <div id="blockers-panel" style="margin-top:1.5rem"></div>
 </div>
+
+%s
 </body>
 </html>`,
 		escapedName, logoutForm(basePath),
 		escapedName,
 		escapedName, editBtnHTML,
-		escapedSchema, badge, autoSyncBadge,
+		escapedSchema, badge, autoSyncTrigger,
 		autoSyncInfoHTML(cfg),
 		syncActionsHTML, cfg.ID,
 		escapedYAML,
+		autoSyncModalHTML(basePath, cfg, canEdit),
 	)
 }
 

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -832,7 +832,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
     pre[class*="language-"] { line-height: 1.5 !important; white-space: pre-wrap; word-break: break-word; font-size: 0.84rem; border-radius: 0.5rem; }
     .line-numbers .line-numbers-rows > span::before { line-height: 1.5; }
     #blockers-panel pre { margin-top: 0.5rem; }
-    #autosync-modal { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%); margin:0; }
+    #autosync-modal { position:fixed; top:50%%; left:50%%; transform:translate(-50%%,-50%%); margin:0; }
     #autosync-modal::backdrop { background:rgba(0,0,0,0.6); }
   </style>
   <script>

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -702,27 +702,29 @@ func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
 		return ""
 	}
 	return fmt.Sprintf(`
-<dialog id="autosync-modal" style="max-width:480px;width:100%%;border-radius:0.75rem;padding:2rem;background:var(--pico-card-background-color);border:1px solid var(--pico-card-border-color);color:var(--pico-color)">
-  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem">
-    <strong style="font-size:1.1rem">⏰ Auto-Sync</strong>
-    <button type="button" onclick="document.getElementById('autosync-modal').close()" style="background:none;border:none;cursor:pointer;font-size:1.3rem;color:var(--pico-muted-color);padding:0;line-height:1">×</button>
-  </div>
-  <p style="font-size:0.88rem;color:var(--pico-muted-color);margin-bottom:1.25rem">
-    Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
-    When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
-  </p>
-  <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML">
-    <label for="modal-sync-schedule">Schedule
-      <select id="modal-sync-schedule" name="sync_schedule">
-        %s
-      </select>
-    </label>
-    <div id="autosync-modal-error" style="min-height:1.5rem;margin-top:0.5rem"></div>
-    <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
-      <button type="button" class="outline secondary" onclick="document.getElementById('autosync-modal').close()">Cancel</button>
-      <button type="submit">Save</button>
+<dialog id="autosync-modal" style="max-width:480px;border-radius:0.75rem;background:var(--pico-card-background-color);border:1px solid var(--pico-card-border-color);color:var(--pico-color)">
+  <article>
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem">
+      <strong style="font-size:1.1rem">⏰ Auto-Sync</strong>
+      <button type="button" onclick="document.getElementById('autosync-modal').close()" style="background:none;border:none;cursor:pointer;font-size:1.3rem;color:var(--pico-muted-color);padding:0;line-height:1">×</button>
     </div>
-  </form>
+    <p style="font-size:0.88rem;color:var(--pico-muted-color);margin-bottom:1.25rem">
+      Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
+      When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
+    </p>
+    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML">
+      <label for="modal-sync-schedule">Schedule
+        <select id="modal-sync-schedule" name="sync_schedule">
+          %s
+        </select>
+      </label>
+      <div id="autosync-modal-error" style="min-height:1.5rem;margin-top:0.5rem"></div>
+      <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
+        <button type="button" class="outline secondary" onclick="document.getElementById('autosync-modal').close()">Cancel</button>
+        <button type="submit">Save</button>
+      </div>
+    </form>
+  </article>
 </dialog>`,
 		cfg.ID, syncScheduleOptions(cfg.SyncSchedule))
 }

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -832,6 +832,8 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
     pre[class*="language-"] { line-height: 1.5 !important; white-space: pre-wrap; word-break: break-word; font-size: 0.84rem; border-radius: 0.5rem; }
     .line-numbers .line-numbers-rows > span::before { line-height: 1.5; }
     #blockers-panel pre { margin-top: 0.5rem; }
+    #autosync-modal { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%); margin:0; }
+    #autosync-modal::backdrop { background:rgba(0,0,0,0.6); }
   </style>
   <script>
     document.addEventListener('htmx:afterSwap', function() { Prism.highlightAll(); });

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -703,30 +703,26 @@ func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
 	}
 	return fmt.Sprintf(`
 <dialog id="autosync-modal" style="max-width:480px;width:100%%;border-radius:0.75rem;padding:2rem;background:var(--pico-card-background-color);border:1px solid var(--pico-card-border-color);color:var(--pico-color)">
-  <article style="margin:0;padding:0;border:none;background:none">
-    <header style="margin-bottom:1rem;padding:0;border:none">
-      <div style="display:flex;align-items:center;justify-content:space-between">
-        <strong style="font-size:1.1rem">⏰ Auto-Sync</strong>
-        <button type="button" onclick="document.getElementById('autosync-modal').close()" style="background:none;border:none;cursor:pointer;font-size:1.3rem;color:var(--pico-muted-color);padding:0;line-height:1">×</button>
-      </div>
-    </header>
-    <p style="font-size:0.88rem;color:var(--pico-muted-color);margin-bottom:1.25rem">
-      Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
-      When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
-    </p>
-    <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML">
-      <label for="modal-sync-schedule">Schedule
-        <select id="modal-sync-schedule" name="sync_schedule">
-          %s
-        </select>
-      </label>
-      <div id="autosync-modal-error" style="min-height:1.5rem;margin-top:0.5rem"></div>
-      <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
-        <button type="button" class="outline secondary" onclick="document.getElementById('autosync-modal').close()">Cancel</button>
-        <button type="submit">Save</button>
-      </div>
-    </form>
-  </article>
+  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem">
+    <strong style="font-size:1.1rem">⏰ Auto-Sync</strong>
+    <button type="button" onclick="document.getElementById('autosync-modal').close()" style="background:none;border:none;cursor:pointer;font-size:1.3rem;color:var(--pico-muted-color);padding:0;line-height:1">×</button>
+  </div>
+  <p style="font-size:0.88rem;color:var(--pico-muted-color);margin-bottom:1.25rem">
+    Auto-Sync automatically reads public holidays and writes blocker events to your calendar on a recurring schedule — no manual action needed.
+    When enabled, manual <strong>Sync</strong> and <strong>Wipe</strong> operations are disabled to prevent conflicts.
+  </p>
+  <form hx-post="`+basePath+`/configs/%d/auto-sync" hx-target="#autosync-modal-error" hx-swap="innerHTML">
+    <label for="modal-sync-schedule">Schedule
+      <select id="modal-sync-schedule" name="sync_schedule">
+        %s
+      </select>
+    </label>
+    <div id="autosync-modal-error" style="min-height:1.5rem;margin-top:0.5rem"></div>
+    <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem">
+      <button type="button" class="outline secondary" onclick="document.getElementById('autosync-modal').close()">Cancel</button>
+      <button type="submit">Save</button>
+    </div>
+  </form>
 </dialog>`,
 		cfg.ID, syncScheduleOptions(cfg.SyncSchedule))
 }

--- a/internal/web/handler/dashboard.go
+++ b/internal/web/handler/dashboard.go
@@ -286,15 +286,17 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
 }
 
 func autoSyncDashBadge(schedule string) string {
-	label := map[string]string{
-		db.SyncScheduleWeekly:  "⏰ weekly",
-		db.SyncScheduleMonthly: "⏰ monthly",
-	}[schedule]
-	if label == "" {
-		return ""
+	type entry struct{ label, style string }
+	m := map[string]entry{
+		db.SyncScheduleWeekly:  {"⏰ weekly", "background:#1e3a5f;color:#60a5fa;border:1px solid #1d4ed8"},
+		db.SyncScheduleMonthly: {"⏰ monthly", "background:#1e3a5f;color:#60a5fa;border:1px solid #1d4ed8"},
 	}
-	return fmt.Sprintf(`<span style="padding:0.2rem 0.6rem;border-radius:999px;font-size:0.78rem;font-weight:600;background:#1e3a5f;color:#60a5fa;border:1px solid #1d4ed8">%s</span>`,
-		html.EscapeString(label))
+	e, ok := m[schedule]
+	if !ok {
+		e = entry{"⏰ off", "background:#1f2937;color:#6b7280;border:1px solid #374151"}
+	}
+	return fmt.Sprintf(`<span style="padding:0.2rem 0.6rem;border-radius:999px;font-size:0.78rem;font-weight:600;%s">%s</span>`,
+		e.style, html.EscapeString(e.label))
 }
 
 func statusBadge(status db.ConfigStatus) string {

--- a/internal/web/handler/dashboard.go
+++ b/internal/web/handler/dashboard.go
@@ -85,6 +85,7 @@ func (h *DashboardHandler) HandleDashboard(w http.ResponseWriter, r *http.Reques
 			Name:         c.Name,
 			Schema:       c.SchemaVersion,
 			Status:       c.Status,
+			SyncSchedule: c.SyncSchedule,
 			Author:       author,
 			CalendarID:   calID,
 			CalendarName: calDisplay,
@@ -117,6 +118,7 @@ type dashRow struct {
 	Name         string
 	Schema       string
 	Status       db.ConfigStatus
+	SyncSchedule string
 	Author       string
 	CalendarID   string
 	CalendarName string
@@ -198,6 +200,7 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
 	} else {
 		for _, r := range rows {
 			badge := statusBadge(r.Status)
+			autoSyncBadge := autoSyncDashBadge(r.SyncSchedule)
 			calDisplay := r.CalendarName
 			if calDisplay == "" {
 				calDisplay = r.CalendarID
@@ -217,6 +220,7 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
     <strong style="font-size:1rem"><a href="`+basePath+`/configs/%d" style="text-decoration:none">%s</a></strong>
     <div style="display:flex;align-items:center;gap:0.5rem;flex-shrink:0">
       %s
+      %s
       <a href="`+basePath+`/configs/%d" role="button" class="outline" style="padding:0.2rem 0.6rem;font-size:0.82rem;margin:0">View</a>
       %s
     </div>
@@ -225,6 +229,7 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
 </article>`,
 				r.ID, html.EscapeString(trunc(r.Name, 50)),
 				badge,
+				autoSyncBadge,
 				r.ID,
 				editBtn,
 				meta)
@@ -278,6 +283,18 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
 			return ""
 		}(),
 		filterBar, cards)
+}
+
+func autoSyncDashBadge(schedule string) string {
+	if schedule == db.SyncScheduleNone || schedule == "" {
+		return ""
+	}
+	label := map[string]string{
+		db.SyncScheduleWeekly:  "⏰ weekly",
+		db.SyncScheduleMonthly: "⏰ monthly",
+	}[schedule]
+	return fmt.Sprintf(`<span style="padding:0.2rem 0.6rem;border-radius:999px;font-size:0.78rem;font-weight:600;background:#1e3a5f;color:#60a5fa;border:1px solid #1d4ed8">%s</span>`,
+		html.EscapeString(label))
 }
 
 func statusBadge(status db.ConfigStatus) string {

--- a/internal/web/handler/dashboard.go
+++ b/internal/web/handler/dashboard.go
@@ -286,13 +286,13 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
 }
 
 func autoSyncDashBadge(schedule string) string {
-	if schedule == db.SyncScheduleNone || schedule == "" {
-		return ""
-	}
 	label := map[string]string{
 		db.SyncScheduleWeekly:  "⏰ weekly",
 		db.SyncScheduleMonthly: "⏰ monthly",
 	}[schedule]
+	if label == "" {
+		return ""
+	}
 	return fmt.Sprintf(`<span style="padding:0.2rem 0.6rem;border-radius:999px;font-size:0.78rem;font-weight:600;background:#1e3a5f;color:#60a5fa;border:1px solid #1d4ed8">%s</span>`,
 		html.EscapeString(label))
 }


### PR DESCRIPTION
## Summary

- **Detail page**: next to `Status: valid`, adds `Auto Sync: off` where the schedule label is a dotted-underline clickable button. Clicking opens a native `<dialog>` modal that explains what Auto-Sync is, provides a schedule picker (off / weekly / monthly), and saves via `POST /configs/{id}/auto-sync` (redirects back on success). Read-only users see the label but cannot open the modal.
- **Dashboard**: adds a blue `⏰ weekly` / `⏰ monthly` pill badge next to the status badge for configs that have auto-sync enabled; no badge for `off`.
- **New endpoint** `POST /configs/{id}/auto-sync` — updates only `sync_schedule` + `next_sync_at`, respects edit permission, guards request body size.

## Test plan

- [ ] Open a config detail page → "Auto Sync: off" appears dotted+clickable next to Status
- [ ] Clicking the label opens the Auto-Sync modal with schedule picker
- [ ] Saving "weekly" → page reloads, label reads "weekly", info box appears
- [ ] Saving "off" → page reloads, label reads "off", manual Sync/Wipe re-enabled
- [ ] Read-only user: label shows but clicking does nothing (no `onclick`)
- [ ] Dashboard: configs with weekly/monthly show the blue pill badge; configs with `none` show nothing
- [ ] `go build ./...`, `golangci-lint run ./...`, `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)