### PR TITLE
fix: persist refreshed OAuth tokens back to DB (fixes #25)

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "9.7%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "9.6%", "color": "red"}

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "9.6%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "10.2%", "color": "red"}

--- a/internal/adapter/googlecalendar/auth.go
+++ b/internal/adapter/googlecalendar/auth.go
@@ -15,6 +15,11 @@ const (
 	oauthScopeProfile = "https://www.googleapis.com/auth/userinfo.profile"
 )
 
+// TokenStore is implemented by db.TokenStore and allows writing refreshed tokens back to persistent storage.
+type TokenStore interface {
+	Upsert(userID int64, token *oauth2.Token) error
+}
+
 // NewOAuthConfig builds an OAuth2 config from environment variables.
 // Reads GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET, GOOGLE_OAUTH_REDIRECT_URL.
 func NewOAuthConfig() *oauth2.Config {
@@ -32,6 +37,37 @@ func NewOAuthConfig() *oauth2.Config {
 }
 
 // NewHTTPClientFromToken creates an authorized HTTP client from a stored token.
+// Tokens refreshed in memory are not persisted; use NewHTTPClientWithPersistence for
+// long-lived operations that must survive refresh token rotation.
 func NewHTTPClientFromToken(ctx context.Context, cfg *oauth2.Config, token *oauth2.Token) *http.Client {
 	return cfg.Client(ctx, token)
+}
+
+// persistingTokenSource wraps an oauth2.TokenSource and writes refreshed tokens back to the DB.
+// This prevents auth failures when Google rotates refresh tokens.
+type persistingTokenSource struct {
+	base    oauth2.TokenSource
+	userID  int64
+	store   TokenStore
+	current *oauth2.Token
+}
+
+func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	t, err := p.base.Token()
+	if err != nil {
+		return nil, err
+	}
+	if t.AccessToken != p.current.AccessToken {
+		_ = p.store.Upsert(p.userID, t)
+		p.current = t
+	}
+	return t, nil
+}
+
+// NewHTTPClientWithPersistence creates an authorized HTTP client that writes refreshed tokens
+// back to the DB via store. Use this for all Google Calendar API calls made on behalf of a stored user.
+func NewHTTPClientWithPersistence(ctx context.Context, cfg *oauth2.Config, token *oauth2.Token, userID int64, store TokenStore) *http.Client {
+	base := cfg.TokenSource(ctx, token)
+	src := &persistingTokenSource{base: base, userID: userID, store: store, current: token}
+	return oauth2.NewClient(ctx, src)
 }

--- a/internal/adapter/googlecalendar/auth.go
+++ b/internal/adapter/googlecalendar/auth.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+
+	"github.com/nvat/tgifreezeday/internal/logging"
 )
 
 const (
@@ -58,7 +60,9 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 		return nil, err
 	}
 	if t.AccessToken != p.current.AccessToken {
-		_ = p.store.Upsert(p.userID, t)
+		if err := p.store.Upsert(p.userID, t); err != nil {
+			logging.GetLogger().WithError(err).Warn("failed to persist refreshed OAuth token")
+		}
 		p.current = t
 	}
 	return t, nil

--- a/internal/adapter/googlecalendar/auth_test.go
+++ b/internal/adapter/googlecalendar/auth_test.go
@@ -1,0 +1,100 @@
+package googlecalendar
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// stubTokenSource returns a fixed token on each call.
+type stubTokenSource struct {
+	token *oauth2.Token
+	err   error
+}
+
+func (s *stubTokenSource) Token() (*oauth2.Token, error) {
+	return s.token, s.err
+}
+
+// stubTokenStore records Upsert calls.
+type stubTokenStore struct {
+	calls []*oauth2.Token
+	err   error
+}
+
+func (s *stubTokenStore) Upsert(_ int64, t *oauth2.Token) error {
+	s.calls = append(s.calls, t)
+	return s.err
+}
+
+func tokenWithAccess(access string) *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  access,
+		RefreshToken: "refresh",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+}
+
+func TestPersistingTokenSource_PersistsOnRefresh(t *testing.T) {
+	initial := tokenWithAccess("old-access")
+	refreshed := tokenWithAccess("new-access")
+
+	store := &stubTokenStore{}
+	src := &persistingTokenSource{
+		base:    &stubTokenSource{token: refreshed},
+		userID:  42,
+		store:   store,
+		current: initial,
+	}
+
+	got, err := src.Token()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AccessToken != "new-access" {
+		t.Errorf("got access token %q, want %q", got.AccessToken, "new-access")
+	}
+	if len(store.calls) != 1 {
+		t.Errorf("Upsert called %d times, want 1", len(store.calls))
+	}
+}
+
+func TestPersistingTokenSource_NoPersistWhenTokenUnchanged(t *testing.T) {
+	tok := tokenWithAccess("same-access")
+
+	store := &stubTokenStore{}
+	src := &persistingTokenSource{
+		base:    &stubTokenSource{token: tok},
+		userID:  42,
+		store:   store,
+		current: tok,
+	}
+
+	if _, err := src.Token(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(store.calls) != 0 {
+		t.Errorf("Upsert called %d times, want 0", len(store.calls))
+	}
+}
+
+func TestPersistingTokenSource_PropagatesBaseError(t *testing.T) {
+	baseErr := errors.New("refresh failed")
+	store := &stubTokenStore{}
+	src := &persistingTokenSource{
+		base:    &stubTokenSource{err: baseErr},
+		userID:  42,
+		store:   store,
+		current: tokenWithAccess("old"),
+	}
+
+	_, err := src.Token()
+	if !errors.Is(err, baseErr) {
+		t.Errorf("got error %v, want %v", err, baseErr)
+	}
+	if len(store.calls) != 0 {
+		t.Errorf("Upsert should not be called on base error, got %d calls", len(store.calls))
+	}
+}

--- a/internal/adapter/googlecalendar/calendars.go
+++ b/internal/adapter/googlecalendar/calendars.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"golang.org/x/oauth2"
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
+
+	"golang.org/x/oauth2"
 )
 
 // CalendarItem represents a calendar the user can write to.
@@ -16,8 +17,8 @@ type CalendarItem struct {
 }
 
 // ListWritableCalendars returns all calendars where the user has owner or writer access.
-func ListWritableCalendars(ctx context.Context, cfg *oauth2.Config, token *oauth2.Token) ([]*CalendarItem, error) {
-	client := cfg.Client(ctx, token)
+func ListWritableCalendars(ctx context.Context, cfg *oauth2.Config, token *oauth2.Token, userID int64, store TokenStore) ([]*CalendarItem, error) {
+	client := NewHTTPClientWithPersistence(ctx, cfg, token, userID, store)
 	svc, err := calendar.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create calendar service: %w", err)

--- a/internal/adapter/googlecalendar/repository.go
+++ b/internal/adapter/googlecalendar/repository.go
@@ -27,10 +27,12 @@ func NewRepositoryWithToken(
 	ctx context.Context,
 	oauthCfg *oauth2.Config,
 	token *oauth2.Token,
+	userID int64,
+	store TokenStore,
 	countryCode,
 	writeCalendarID string,
 ) (*Repository, error) {
-	httpClient := NewHTTPClientFromToken(ctx, oauthCfg, token)
+	httpClient := NewHTTPClientWithPersistence(ctx, oauthCfg, token, userID, store)
 
 	service, err := calendar.NewService(ctx, option.WithHTTPClient(httpClient))
 	if err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -127,7 +127,7 @@ func (s *Scheduler) runSync(ctx context.Context, cfg *db.Config) (string, bool) 
 	if token == nil {
 		return "no OAuth token for config owner — owner must log in", true
 	}
-	repo, err := googlecalendar.NewRepositoryWithToken(ctx, s.oauthCfg, token,
+	repo, err := googlecalendar.NewRepositoryWithToken(ctx, s.oauthCfg, token, cfg.UserID, s.tokens,
 		appCfg.ReadFrom.GoogleCalendar.CountryCode,
 		appCfg.WriteTo.GoogleCalendar.ID,
 	)

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -56,7 +56,7 @@ func (h *ConfigHandler) fetchCalendars(ctx context.Context, userID int64) []*goo
 	if err != nil {
 		return nil
 	}
-	items, err := googlecalendar.ListWritableCalendars(ctx, h.oauthCfg, token)
+	items, err := googlecalendar.ListWritableCalendars(ctx, h.oauthCfg, token, userID, h.tokens)
 	if err != nil {
 		log.WithError(err).Warn("failed to list writable calendars for form")
 		return nil
@@ -403,7 +403,7 @@ func (h *ConfigHandler) validateConfig(ctx context.Context, userID int64, yamlCo
 	if err != nil {
 		return db.ConfigStatusInvalid, err.Error()
 	}
-	_, err = googlecalendar.NewRepositoryWithToken(ctx, h.oauthCfg, token,
+	_, err = googlecalendar.NewRepositoryWithToken(ctx, h.oauthCfg, token, userID, h.tokens,
 		appCfg.ReadFrom.GoogleCalendar.CountryCode,
 		appCfg.WriteTo.GoogleCalendar.ID,
 	)
@@ -436,7 +436,7 @@ func (h *ConfigHandler) buildRepo(ctx context.Context, userID int64, cfg *appcon
 	if err != nil {
 		return nil, err
 	}
-	return googlecalendar.NewRepositoryWithToken(ctx, h.oauthCfg, token,
+	return googlecalendar.NewRepositoryWithToken(ctx, h.oauthCfg, token, userID, h.tokens,
 		cfg.ReadFrom.GoogleCalendar.CountryCode,
 		cfg.WriteTo.GoogleCalendar.ID,
 	)

--- a/internal/web/handler/dashboard.go
+++ b/internal/web/handler/dashboard.go
@@ -57,7 +57,7 @@ func (h *DashboardHandler) HandleDashboard(w http.ResponseWriter, r *http.Reques
 	// Fetch current user's calendar names in one API call for display
 	calNames := map[string]string{}
 	if token, err := h.tokens.Get(currentUser.ID); err == nil && token != nil {
-		if cals, err := googlecalendar.ListWritableCalendars(r.Context(), h.oauthCfg, token); err == nil {
+		if cals, err := googlecalendar.ListWritableCalendars(r.Context(), h.oauthCfg, token, currentUser.ID, h.tokens); err == nil {
 			for _, c := range cals {
 				calNames[c.ID] = c.Summary
 			}


### PR DESCRIPTION
## Summary

- Adds a `persistingTokenSource` wrapper in `internal/adapter/googlecalendar/auth.go` that calls `tokens.Upsert()` whenever the underlying `oauth2.TokenSource` issues a new access token (i.e., after a silent refresh).
- Adds `NewHTTPClientWithPersistence` as the replacement for `cfg.Client()` in all long-lived calendar API calls.
- Threads `userID` and `TokenStore` through `NewRepositoryWithToken`, `ListWritableCalendars`, and the scheduler's `runSync` so every refresh is persisted.
- The original `NewHTTPClientFromToken` (in-memory only) is kept for the login-time `fetchUserInfo` call where no `userID` is available yet.

## Root cause (issue #25)

`cfg.Client(ctx, token)` creates a throw-away in-memory `reuseTokenSource`. When Google silently refreshes an expired access token — and rotates the refresh token — the new token exists only in memory for that single request. The DB is never updated, so the next cold load presents the old invalidated refresh token to Google → `invalid_grant` / "Token has been expired or revoked" error.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -v` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l .` — no changes needed
- [ ] Manual: log in, simulate token expiry (set a short `Expiry` in DB), reload app → no error; confirm `oauth_tokens.updated_at` advances

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)