### PR TITLE
feat: configurable blocker event start/end time (startTime/endTime)

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "10.2%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "11.3%", "color": "red"}

--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ writeTo:
 
     # what to do if today is Freeze day
     ifTodayIsFreezeDay:
-      # Modifying the default blocker event: change summary and description.
+      # Modifying the default blocker event: change summary, description, and time window.
       # Description supports html tags (this is Google Cal feature, we just reuse it, it may change though we don't guarantee support)
       default:
         summary: "🚫 PRODUCTION FREEZE - No Deployments"
         description: |
           Production operations restricted today.<br>
           <a href="https://wiki.company.com/freeze-policy">Freeze Policy</a>
+        startTime: "08:00"  # optional, HH:MM format, default "08:00"
+        endTime: "20:00"    # optional, HH:MM format, default "20:00"
 ```
 
 ### Freeze Day Rules

--- a/internal/adapter/googlecalendar/repository.go
+++ b/internal/adapter/googlecalendar/repository.go
@@ -224,8 +224,14 @@ func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description, st
 	// Convert to calendar timezone for proper display
 	calendarDate := date.In(r.calendarTZ)
 
-	parsedStart, _ := time.Parse("15:04", startTime)
-	parsedEnd, _ := time.Parse("15:04", endTime)
+	parsedStart, err := time.Parse("15:04", startTime)
+	if err != nil {
+		return fmt.Errorf("invalid startTime %q: %w", startTime, err)
+	}
+	parsedEnd, err := time.Parse("15:04", endTime)
+	if err != nil {
+		return fmt.Errorf("invalid endTime %q: %w", endTime, err)
+	}
 
 	startDateTime := time.Date(
 		calendarDate.Year(), calendarDate.Month(), calendarDate.Day(),
@@ -254,8 +260,7 @@ func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description, st
 		Description: finalDescription,
 	})
 
-	_, err := call.Do()
-	if err != nil {
+	if _, err := call.Do(); err != nil {
 		return fmt.Errorf("failed to write default blocker on date: %w", err)
 	}
 

--- a/internal/adapter/googlecalendar/repository.go
+++ b/internal/adapter/googlecalendar/repository.go
@@ -104,8 +104,6 @@ func (r *Repository) GetFreezeDaysInRange(rangeStart, rangeEnd time.Time) (*doma
 }
 
 const (
-	defaultStartHour          = 8  // local time
-	defaultEndHour            = 20 // local time
 	defaultBlockerSignature   = "Managed by tgifreezeday, do not modify."
 	defaultBlockerDescription = "" + defaultBlockerSignature
 )
@@ -222,18 +220,21 @@ func (r *Repository) ListAllBlockersInRange(startDate, endDate time.Time) ([]*Bl
 	return blockers, nil
 }
 
-func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description string) error {
+func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description, startTime, endTime string) error {
 	// Convert to calendar timezone for proper display
 	calendarDate := date.In(r.calendarTZ)
 
+	parsedStart, _ := time.Parse("15:04", startTime)
+	parsedEnd, _ := time.Parse("15:04", endTime)
+
 	startDateTime := time.Date(
 		calendarDate.Year(), calendarDate.Month(), calendarDate.Day(),
-		defaultStartHour, 0, 0, 0,
+		parsedStart.Hour(), parsedStart.Minute(), 0, 0,
 		r.calendarTZ)
 
 	endDateTime := time.Date(
 		calendarDate.Year(), calendarDate.Month(), calendarDate.Day(),
-		defaultEndHour, 0, 0, 0,
+		parsedEnd.Hour(), parsedEnd.Minute(), 0, 0,
 		r.calendarTZ)
 
 	// Combine custom description with signature for identification

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,8 @@ type IfTodayIsFreezeDayConfig struct {
 type DefaultConfig struct {
 	Summary     *string `yaml:"summary"`
 	Description *string `yaml:"description"`
+	StartTime   *string `yaml:"startTime"`
+	EndTime     *string `yaml:"endTime"`
 }
 
 type Config struct {
@@ -65,5 +67,11 @@ func (c *Config) SetDefault() {
 	}
 	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description == nil {
 		c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description = helpers.StringPtr(defaultDescription)
+	}
+	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime == nil {
+		c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime = helpers.StringPtr("08:00")
+	}
+	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime == nil {
+		c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime = helpers.StringPtr("20:00")
 	}
 }

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/nvat/tgifreezeday/internal/consts"
 )
@@ -130,5 +131,25 @@ func (c *Config) SetDefaultAndValidateWriteToGoogleCalendarIfTodayIsFreezeDay() 
 		return fmt.Errorf("writeTo.googleCalendar.ifTodayIsFreezeDay.default.description cannot be longer than 8000 characters")
 	}
 
+	startT, err := parseHHMM(*c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime)
+	if err != nil {
+		return fmt.Errorf("writeTo.googleCalendar.ifTodayIsFreezeDay.default.startTime: %w", err)
+	}
+	endT, err := parseHHMM(*c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime)
+	if err != nil {
+		return fmt.Errorf("writeTo.googleCalendar.ifTodayIsFreezeDay.default.endTime: %w", err)
+	}
+	if !startT.Before(endT) {
+		return fmt.Errorf("writeTo.googleCalendar.ifTodayIsFreezeDay.default.startTime must be before endTime")
+	}
+
 	return nil
+}
+
+func parseHHMM(s string) (time.Time, error) {
+	t, err := time.Parse("15:04", s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%q is not a valid HH:MM time", s)
+	}
+	return t, nil
 }

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -77,6 +77,7 @@ func Test_ConfigValidate(t *testing.T) {
 		{name: "invalid_startTime_format", yaml: mockConfigYamlInvalidStartTimeFormat, want: nil},
 		{name: "invalid_endTime_format", yaml: mockConfigYamlInvalidEndTimeFormat, want: nil},
 		{name: "invalid_startTime_after_endTime", yaml: mockConfigYamlInvalidStartAfterEnd, want: nil},
+		{name: "invalid_startTime_equals_endTime", yaml: mockConfigYamlInvalidStartEqualsEnd, want: nil},
 	}
 
 	for _, test := range tests {

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -41,6 +41,14 @@ func configsEqual(a, b *Config) bool {
 		return false
 	}
 
+	if !stringPtrsEqual(aDefault.StartTime, bDefault.StartTime) {
+		return false
+	}
+
+	if !stringPtrsEqual(aDefault.EndTime, bDefault.EndTime) {
+		return false
+	}
+
 	return true
 }
 
@@ -62,9 +70,13 @@ func Test_ConfigValidate(t *testing.T) {
 		want *Config
 	}{
 		{name: "valid", yaml: mockConfigYamlValid, want: mockValidParsedConfig},
+		{name: "valid_custom_times", yaml: mockConfigYamlCustomTimes, want: mockCustomTimesParsedConfig},
 		{name: "invalid_countryCode", yaml: mockConfigYamlInvalidCountryCode, want: nil},
 		{name: "invalid_unsupportedDate", yaml: mockConfigYamlInvalidUnsupportedDate, want: nil},
 		{name: "invalid_unsupportedCheck", yaml: mockConfigYamlInvalidUnsupportedCheck, want: nil},
+		{name: "invalid_startTime_format", yaml: mockConfigYamlInvalidStartTimeFormat, want: nil},
+		{name: "invalid_endTime_format", yaml: mockConfigYamlInvalidEndTimeFormat, want: nil},
+		{name: "invalid_startTime_after_endTime", yaml: mockConfigYamlInvalidStartAfterEnd, want: nil},
 	}
 
 	for _, test := range tests {

--- a/internal/config/config_validate_testdata.go
+++ b/internal/config/config_validate_testdata.go
@@ -53,6 +53,8 @@ var mockValidParsedConfig = &Config{
 				Default: DefaultConfig{
 					Summary:     helpers.StringPtr("Today is FREEZE-DAY. no PROD operation is allowed."),
 					Description: helpers.StringPtr("Managed by tgifreezeday, do not modify."),
+					StartTime:   helpers.StringPtr("08:00"),
+					EndTime:     helpers.StringPtr("20:00"),
 				},
 			},
 		},
@@ -101,6 +103,110 @@ writeTo:
       default:
         summary: "Today is FREEZE-DAY. no PROD operation is allowed." 
         description: "Managed by tgifreezeday, do not modify."
+`
+
+const mockConfigYamlCustomTimes = `
+shared:
+  lookbackDays: 20
+  lookaheadDays: 60
+readFrom:
+  googleCalendar:
+    countryCode: "jpn"
+    todayIsFreezeDayIf:
+      - today:
+        - isTheFirstBusinessDayOfTheMonth
+writeTo:
+  googleCalendar:
+    id: "example-freeze@example.com"
+    ifTodayIsFreezeDay:
+      default:
+        startTime: "09:30"
+        endTime: "18:00"
+`
+
+var mockCustomTimesParsedConfig = &Config{
+	Shared: SharedConfig{
+		LookbackDays:  20,
+		LookaheadDays: 60,
+	},
+	ReadFrom: ReadFromConfig{
+		GoogleCalendar: GoogleCalendarReadConfig{
+			CountryCode: "jpn",
+			TodayIsFreezeDayIf: []map[string][]string{
+				{"today": []string{"isTheFirstBusinessDayOfTheMonth"}},
+			},
+		},
+	},
+	WriteTo: WriteToConfig{
+		GoogleCalendar: GoogleCalendarWriteConfig{
+			ID: "example-freeze@example.com",
+			IfTodayIsFreezeDay: IfTodayIsFreezeDayConfig{
+				Default: DefaultConfig{
+					Summary:     helpers.StringPtr("Today is FREEZE-DAY. no PROD operation is allowed."),
+					Description: helpers.StringPtr("Managed by tgifreezeday, do not modify."),
+					StartTime:   helpers.StringPtr("09:30"),
+					EndTime:     helpers.StringPtr("18:00"),
+				},
+			},
+		},
+	},
+}
+
+const mockConfigYamlInvalidStartTimeFormat = `
+shared:
+  lookbackDays: 20
+  lookaheadDays: 60
+readFrom:
+  googleCalendar:
+    countryCode: "jpn"
+    todayIsFreezeDayIf:
+      - today:
+        - isTheFirstBusinessDayOfTheMonth
+writeTo:
+  googleCalendar:
+    id: "example-freeze@example.com"
+    ifTodayIsFreezeDay:
+      default:
+        startTime: "8am"
+        endTime: "20:00"
+`
+
+const mockConfigYamlInvalidEndTimeFormat = `
+shared:
+  lookbackDays: 20
+  lookaheadDays: 60
+readFrom:
+  googleCalendar:
+    countryCode: "jpn"
+    todayIsFreezeDayIf:
+      - today:
+        - isTheFirstBusinessDayOfTheMonth
+writeTo:
+  googleCalendar:
+    id: "example-freeze@example.com"
+    ifTodayIsFreezeDay:
+      default:
+        startTime: "08:00"
+        endTime: "25:00"
+`
+
+const mockConfigYamlInvalidStartAfterEnd = `
+shared:
+  lookbackDays: 20
+  lookaheadDays: 60
+readFrom:
+  googleCalendar:
+    countryCode: "jpn"
+    todayIsFreezeDayIf:
+      - today:
+        - isTheFirstBusinessDayOfTheMonth
+writeTo:
+  googleCalendar:
+    id: "example-freeze@example.com"
+    ifTodayIsFreezeDay:
+      default:
+        startTime: "20:00"
+        endTime: "08:00"
 `
 
 const mockConfigYamlInvalidUnsupportedCheck = `

--- a/internal/config/config_validate_testdata.go
+++ b/internal/config/config_validate_testdata.go
@@ -209,6 +209,25 @@ writeTo:
         endTime: "08:00"
 `
 
+const mockConfigYamlInvalidStartEqualsEnd = `
+shared:
+  lookbackDays: 20
+  lookaheadDays: 60
+readFrom:
+  googleCalendar:
+    countryCode: "jpn"
+    todayIsFreezeDayIf:
+      - today:
+        - isTheFirstBusinessDayOfTheMonth
+writeTo:
+  googleCalendar:
+    id: "example-freeze@example.com"
+    ifTodayIsFreezeDay:
+      default:
+        startTime: "10:00"
+        endTime: "10:00"
+`
+
 const mockConfigYamlInvalidUnsupportedCheck = `
 shared:
   lookbackDays: 20

--- a/internal/config/schema-v1.yaml
+++ b/internal/config/schema-v1.yaml
@@ -51,3 +51,15 @@ fields:
     required: false
     maxLength: 8000
     description: Event description, HTML supported (default provided if omitted)
+
+  writeTo.googleCalendar.ifTodayIsFreezeDay.default.startTime:
+    type: string
+    required: false
+    format: "HH:MM"
+    description: Event start time in HH:MM format (default "08:00"). Must be before endTime.
+
+  writeTo.googleCalendar.ifTodayIsFreezeDay.default.endTime:
+    type: string
+    required: false
+    format: "HH:MM"
+    description: Event end time in HH:MM format (default "20:00"). Must be after startTime.

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -7,5 +7,5 @@ import (
 type TGIFCalendarRepository interface {
 	GetFreezeDaysInRange(rangeStart, rangeEnd time.Time) (*TGIFMapping, error)
 	WipeAllBlockersInRange(startDate, endDate time.Time) error
-	WriteBlockerOnDate(date time.Time, summary, description string) error
+	WriteBlockerOnDate(date time.Time, summary, description, startTime, endTime string) error
 }

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -13,7 +13,7 @@ func RunSync(
 	repo TGIFCalendarRepository,
 	rangeStart, rangeEnd time.Time,
 	rules TodayIsFreezeDayIf,
-	summary, description string,
+	summary, description, startTime, endTime string,
 ) (string, bool) {
 	tgifMapping, err := repo.GetFreezeDaysInRange(rangeStart, rangeEnd)
 	if err != nil {
@@ -25,7 +25,7 @@ func RunSync(
 	count := 0
 	for _, day := range *tgifMapping {
 		if day.IsTodayFreezeDay(rules) {
-			if err := repo.WriteBlockerOnDate(day.Date, summary, description); err != nil {
+			if err := repo.WriteBlockerOnDate(day.Date, summary, description, startTime, endTime); err != nil {
 				return fmt.Sprintf("failed to write blocker on %s: %s", day.Date.Format("2006-01-02"), err.Error()), true
 			}
 			count++

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -141,6 +141,8 @@ func (s *Scheduler) runSync(ctx context.Context, cfg *db.Config) (string, bool) 
 		domain.TodayIsFreezeDayIf(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf),
 		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary,
 		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description,
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime,
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime,
 	)
 }
 

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -458,6 +458,8 @@ func (h *ConfigHandler) runSync(ctx context.Context, userID int64, cfg *db.Confi
 		domain.TodayIsFreezeDayIf(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf),
 		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary,
 		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description,
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime,
+		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime,
 	)
 }
 


### PR DESCRIPTION
## Summary

- Adds optional `startTime` and `endTime` fields to `writeTo.googleCalendar.ifTodayIsFreezeDay.default` in config YAML
- Both fields accept `HH:MM` format (e.g. `"08:00"`, `"09:30"`)
- Defaults remain `"08:00"` / `"20:00"` — existing configs are unaffected
- Validation rejects invalid formats and enforces `startTime < endTime`

Closes #21

## Usage

```yaml
writeTo:
  googleCalendar:
    ifTodayIsFreezeDay:
      default:
        summary: "🚫 PRODUCTION FREEZE"
        startTime: "09:00"   # optional, default "08:00"
        endTime: "18:00"     # optional, default "20:00"
```

## Test plan

- [ ] `go test ./...` passes (includes new cases: custom times, invalid format, start >= end)
- [ ] `golangci-lint run ./...` passes
- [ ] Existing configs with no `startTime`/`endTime` continue to create events 08:00–20:00
- [ ] Config with `startTime: "09:30"` / `endTime: "18:00"` creates events at those times
- [ ] Config with `startTime: "8am"` is rejected with a clear error message
- [ ] Config with `startTime: "20:00"` / `endTime: "08:00"` is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)