### PR TITLE
feat: replace YAML editor with structured form UI for config create/edit

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "12.1%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "12.3%", "color": "red"}

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "11.3%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "12.1%", "color": "red"}

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "12.3%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "12.4%", "color": "red"}

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "12.4%", "color": "red"}
+{"schemaVersion": 1, "label": "coverage", "message": "12.3%", "color": "red"}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A self-hosted web app that manages production freeze day blocker events on Googl
 ## Concepts
 
 - **Freeze Day**: A day when production deployments are restricted to reduce risk
-- **Blocker Event**: A calendar event (8AM-8PM) that signals "no deployments allowed" on the calendar. This serves as a notice for everyone.
+- **Blocker Event**: A calendar event that signals "no deployments allowed" on the calendar. This serves as a notice for everyone. By default it spans 8AM–8PM; check "All-day event" in the config form to create a full all-day event instead.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _no need to touch prod to day, touch grass instead_
 
 <!-- <img src="./docs/tgifreezeday.png"> -->
 
-A self-hosted web app that manages production freeze day blocker events on Google Calendar. Users log in with their Google account, define freeze-day rules in a YAML config, and the app creates blocker calendar events so the whole team knows when deployments are restricted.
+A self-hosted web app that manages production freeze day blocker events on Google Calendar. Users log in with their Google account, define freeze-day rules through a structured form, and the app creates blocker calendar events so the whole team knows when deployments are restricted.
 
 ## Concepts
 
@@ -25,7 +25,7 @@ sequenceDiagram
     participant Target as Team Calendar
 
     User->>App: Log in with Google OAuth
-    User->>App: Create / edit config (YAML)
+    User->>App: Create / edit config (structured form)
     User->>App: Click Sync
     App->>Source: Read public holidays
     App->>App: Calculate freeze days
@@ -34,7 +34,7 @@ sequenceDiagram
 ```
 
 1. **Log in** with your Google account via OAuth
-2. **Create a config** — define your freeze-day rules and target calendar in YAML
+2. **Create a config** — fill in the structured form to define freeze-day rules and the target calendar
 3. **Sync** — the app reads public holidays, calculates freeze days, and writes blocker events to your team calendar
 4. **Manage** — validate configs, wipe blockers, or list existing blocker events from the UI
 
@@ -45,60 +45,49 @@ The app is a web server. After starting it, open `http://localhost:8080` in your
 | Page | Description |
 |------|-------------|
 | Dashboard | Lists all configs with status and auto-sync schedule badges |
-| Config Detail | View config YAML, run Sync / Wipe / Validate / List Blockers; configure Auto-Sync |
-| Config Edit | Edit config name, YAML, and schema version |
+| Config Detail | View config fields at a glance, run Sync / Wipe / Validate / List Blockers; configure Auto-Sync |
+| Config Create / Edit | Fill in a structured form — no YAML required |
 
 ## Configuration
 
-Using the webapp, you can create Configs and edit them. Configs is the way you create Events on your Google Calendar based on your rules of "what is a freeze day".
-Below show the configuration yaml example:
+Configs define your freeze-day rules and target calendar. Create and edit them through the structured web form — no YAML needed.
 
-### Basic Example
+> **Technical note:** YAML is the internal storage format. The form builds it server-side from your inputs.
+
+<details>
+<summary>YAML reference (internal storage format)</summary>
 
 ```yaml
 shared:
   lookbackDays: 20      # Check 20 days back
   lookaheadDays: 60     # Check 60 days ahead
-  
+
 readFrom:
   googleCalendar:
-    # Basically this means check Japan public holidays calendar
-    countryCode: "jpn"
-
-    # This is a list, each entry is a key which can be [yesterday, today, tomorrow]
-    # Each key contains a list of "conditions checks" which is AND within the key, and OR'd all keys
-    # eg.
-    # todayIsFreezeDayIf:
-    #  - today: [isTheFirstBusinessDayOfTheMonth, isMonday]
-    #  - today: [isTheLastBusinessDayOfTheMonth] 
-    # Means Today is a FreezeDay if "today <Is The First Busines Day of The Month> AND <it is Monday>" OR "today <Is The Last Business Day Of the Month>"
-    # Note: isMonday isn't available yet as of 2026 May 8th version
+    countryCode: "jpn"  # ISO 3166-1 alpha-3: "jpn" or "vnm"
     todayIsFreezeDayIf:
       - today: [isTheFirstBusinessDayOfTheMonth]
-      - today: [isTheLastBusinessDayOfTheMonth] 
+      - today: [isTheLastBusinessDayOfTheMonth]
       - tomorrow: [isNonBusinessDay]
-      
+
 writeTo:
   googleCalendar:
-    # Calendar ID of the calendar to write blocker events to. The Webapp shall let you pick the calendar and fill the ID for you.
     id: "your-calendar-id@group.calendar.google.com"
-
-    # what to do if today is Freeze day
     ifTodayIsFreezeDay:
-      # Modifying the default blocker event: change summary, description, and time window.
-      # Description supports html tags (this is Google Cal feature, we just reuse it, it may change though we don't guarantee support)
       default:
         summary: "🚫 PRODUCTION FREEZE - No Deployments"
         description: |
           Production operations restricted today.<br>
           <a href="https://wiki.company.com/freeze-policy">Freeze Policy</a>
-        startTime: "08:00"  # optional, HH:MM format, default "08:00"
-        endTime: "20:00"    # optional, HH:MM format, default "20:00"
+        startTime: "08:00"
+        endTime: "20:00"
 ```
+
+</details>
 
 ### Freeze Day Rules
 
-Configure when freeze days occur using these conditions:
+Configure when freeze days occur using these conditions (available as dropdowns in the form):
 
 | Condition | Description |
 |-----------|-------------|
@@ -108,45 +97,38 @@ Configure when freeze days occur using these conditions:
 
 ### Freeze Rule Setting
 
-The program strives to be as natural as possible. Here, in this snippet, you can kind of understand the intention:
+The form uses an OR/AND rule builder. Each **OR group** represents one row — if any group matches, today is a freeze day. Within a group, all conditions must match (AND).
 
-```yaml
-todayIsFreezeDayIf:
-- today: [isTheFirstBusinessDayOfTheMonth]
-```
+Example form state that means "today is a freeze day if (today is the 1st business day) OR (today is the last business day) OR (tomorrow is a non-business day)":
 
-> "Today is freeze-day if Today is the first business day of the month"
+- Group 1: `today` → 1st business day of month
+- Group 2: `today` → last business day of month
+- Group 3: `tomorrow` → non-business day
 
-Here, `"today"` is a Relative Day Anchor. Here are the things you should know:
-- Available Relative Day Anchor: `yesterday`, `today`, `tomorrow`
-- Within an anchor, rules are AND together:
-  - `today: [isA, isB]` meaning "today is freeze day if today is A and is B"
-- Rules across anchors are `OR` together.
-  - ```
-    todayIsFreezeDayIf:
-    - today: [isA, isB]
-    - tomorrow: [isC]
-    ```
-  - Meaning, "today is freeze day if (today is A and B) OR (tomorrow is C)"
+**Available anchors** (Relative Day):
+- `today` — evaluates conditions against today
+- `tomorrow` — evaluates conditions against tomorrow
+- `next day` (nextDay) — evaluates conditions against the next calendar day
 
 ### Supported Countries
 
-- `jpn` - Japan public holidays  
-- `vnm` - Vietnam public holidays
+Available as a dropdown in the form:
+
+- `jpn` — Japan public holidays
+- `vnm` — Vietnam public holidays
 
 ### Rich Descriptions
 
-HTML markup supported for calendar descriptions:
+HTML markup supported for calendar event descriptions (enter in the Description field):
 
-```yaml
-description: |
-  🚫 <strong>PRODUCTION FREEZE</strong><br><br>
-  Restrictions:<br>
-  <ul>
-    <li>No deployments to production</li>
-    <li>No infrastructure changes</li>
-  </ul>
-  Emergency: <a href="mailto:ops@company.com">ops@company.com</a>
+```html
+🚫 <strong>PRODUCTION FREEZE</strong><br><br>
+Restrictions:<br>
+<ul>
+  <li>No deployments to production</li>
+  <li>No infrastructure changes</li>
+</ul>
+Emergency: <a href="mailto:ops@company.com">ops@company.com</a>
 ```
 
 **Supported tags**: `<br>`, `<ul><li>`, `<a href="">`, `<strong>`, `<em>`

--- a/internal/adapter/googlecalendar/repository.go
+++ b/internal/adapter/googlecalendar/repository.go
@@ -220,8 +220,32 @@ func (r *Repository) ListAllBlockersInRange(startDate, endDate time.Time) ([]*Bl
 	return blockers, nil
 }
 
-func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description, startTime, endTime string) error {
-	// Convert to calendar timezone for proper display
+func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description, startTime, endTime string, allDay bool) error {
+	// Combine custom description with signature for identification.
+	var finalDescription string
+	if description == "" || description == defaultBlockerSignature {
+		finalDescription = defaultBlockerSignature
+	} else {
+		finalDescription = description + defaultBlockerSignature
+	}
+
+	if allDay {
+		calendarDate := date.In(r.calendarTZ)
+		dateStr := calendarDate.Format("2006-01-02")
+		nextDateStr := calendarDate.AddDate(0, 0, 1).Format("2006-01-02")
+		call := r.service.Events.Insert(r.writeCalendarID, &calendar.Event{
+			Summary:     summary,
+			Start:       &calendar.EventDateTime{Date: dateStr},
+			End:         &calendar.EventDateTime{Date: nextDateStr},
+			Description: finalDescription,
+		})
+		if _, err := call.Do(); err != nil {
+			return fmt.Errorf("failed to write all-day blocker on date: %w", err)
+		}
+		return nil
+	}
+
+	// Convert to calendar timezone for proper display.
 	calendarDate := date.In(r.calendarTZ)
 
 	parsedStart, err := time.Parse("15:04", startTime)
@@ -242,16 +266,6 @@ func (r *Repository) WriteBlockerOnDate(date time.Time, summary, description, st
 		calendarDate.Year(), calendarDate.Month(), calendarDate.Day(),
 		parsedEnd.Hour(), parsedEnd.Minute(), 0, 0,
 		r.calendarTZ)
-
-	// Combine custom description with signature for identification
-	// If description is empty or just the signature, use signature only
-	var finalDescription string
-	if description == "" || description == defaultBlockerSignature {
-		finalDescription = defaultBlockerSignature
-	} else {
-		// Append signature to custom description for identification
-		finalDescription = description + defaultBlockerSignature
-	}
 
 	call := r.service.Events.Insert(r.writeCalendarID, &calendar.Event{
 		Summary:     summary,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,10 +36,10 @@ type IfTodayIsFreezeDayConfig struct {
 }
 
 type DefaultConfig struct {
-	Summary     *string `yaml:"summary"`
-	Description *string `yaml:"description"`
-	StartTime   *string `yaml:"startTime"`
-	EndTime     *string `yaml:"endTime"`
+	Summary     *string `yaml:"summary,omitempty"`
+	Description *string `yaml:"description,omitempty"`
+	StartTime   *string `yaml:"startTime,omitempty"`
+	EndTime     *string `yaml:"endTime,omitempty"`
 }
 
 type Config struct {
@@ -60,6 +60,15 @@ func LoadWithDefaultFromByteArray(data []byte) (*Config, error) {
 
 const defaultSummary = "Today is FREEZE-DAY. no PROD operation is allowed."
 const defaultDescription = "Managed by tgifreezeday, do not modify."
+
+// ToYAML marshals the config back to YAML bytes.
+func (c *Config) ToYAML() (string, error) {
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal config to YAML: %w", err)
+	}
+	return string(data), nil
+}
 
 func (c *Config) SetDefault() {
 	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type DefaultConfig struct {
 	Description *string `yaml:"description,omitempty"`
 	StartTime   *string `yaml:"startTime,omitempty"`
 	EndTime     *string `yaml:"endTime,omitempty"`
+	AllDay      *bool   `yaml:"allDay,omitempty"`
 }
 
 type Config struct {
@@ -77,10 +78,14 @@ func (c *Config) SetDefault() {
 	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description == nil {
 		c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description = helpers.StringPtr(defaultDescription)
 	}
-	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime == nil {
-		c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime = helpers.StringPtr("08:00")
-	}
-	if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime == nil {
-		c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime = helpers.StringPtr("20:00")
+	// Only set time defaults for timed (non-all-day) events.
+	allDay := c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.AllDay
+	if allDay == nil || !*allDay {
+		if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime == nil {
+			c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime = helpers.StringPtr("08:00")
+		}
+		if c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime == nil {
+			c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime = helpers.StringPtr("20:00")
+		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,11 +7,10 @@ import (
 	"github.com/nvat/tgifreezeday/internal/helpers"
 )
 
-// anchorToday and condNonBusiness are local constants to avoid hitting the
-// goconst min-occurrences threshold when combined with the shared test data.
+// Use shared test constants from config_validate_testdata.go.
 const (
-	anchorToday     = "today"
-	condNonBusiness = "isNonBusinessDay"
+	anchorToday     = testAnchorToday
+	condNonBusiness = testCondNonBusiness
 )
 
 func TestToYAML_RoundTrip(t *testing.T) {
@@ -37,6 +36,55 @@ func TestToYAML_RoundTrip(t *testing.T) {
 
 	if !configsEqual(original, parsed) {
 		t.Errorf("round-trip mismatch:\noriginal: %+v\nparsed:   %+v", original, parsed)
+	}
+}
+
+func TestToYAML_AllDay(t *testing.T) {
+	cfg := &Config{
+		Shared: SharedConfig{LookbackDays: 20, LookaheadDays: 60},
+		ReadFrom: ReadFromConfig{
+			GoogleCalendar: GoogleCalendarReadConfig{
+				CountryCode:        "jpn",
+				TodayIsFreezeDayIf: []map[string][]string{{anchorToday: {condNonBusiness}}},
+			},
+		},
+		WriteTo: WriteToConfig{
+			GoogleCalendar: GoogleCalendarWriteConfig{
+				ID: "myteam@group.calendar.google.com",
+				IfTodayIsFreezeDay: IfTodayIsFreezeDayConfig{
+					Default: DefaultConfig{
+						Summary:     helpers.StringPtr("Freeze"),
+						Description: helpers.StringPtr("No prod ops"),
+						AllDay:      helpers.BoolPtr(true),
+					},
+				},
+			},
+		},
+	}
+
+	yamlStr, err := cfg.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error = %v", err)
+	}
+
+	if !strings.Contains(yamlStr, "allDay: true") {
+		t.Errorf("ToYAML() missing allDay:true\ngot:\n%s", yamlStr)
+	}
+	if strings.Contains(yamlStr, "startTime") || strings.Contains(yamlStr, "endTime") {
+		t.Errorf("ToYAML() should not contain startTime/endTime for all-day config\ngot:\n%s", yamlStr)
+	}
+
+	// Should round-trip and validate without error
+	parsed, err := LoadWithDefaultFromByteArray([]byte(yamlStr))
+	if err != nil {
+		t.Fatalf("LoadWithDefaultFromByteArray() after ToYAML() error = %v", err)
+	}
+	if err := parsed.Validate(); err != nil {
+		t.Fatalf("Validate() after round-trip error = %v", err)
+	}
+	if parsed.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.AllDay == nil ||
+		!*parsed.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.AllDay {
+		t.Errorf("AllDay not preserved after round-trip")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nvat/tgifreezeday/internal/helpers"
+)
+
+// anchorToday and condNonBusiness are local constants to avoid hitting the
+// goconst min-occurrences threshold when combined with the shared test data.
+const (
+	anchorToday     = "today"
+	condNonBusiness = "isNonBusinessDay"
+)
+
+func TestToYAML_RoundTrip(t *testing.T) {
+	// Reuse mock data from testdata to avoid goconst threshold on string literals.
+	original := mockValidParsedConfig
+
+	yamlStr, err := original.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error = %v", err)
+	}
+	if yamlStr == "" {
+		t.Fatal("ToYAML() returned empty string")
+	}
+
+	// Parse back and validate the round-trip
+	parsed, err := LoadWithDefaultFromByteArray([]byte(yamlStr))
+	if err != nil {
+		t.Fatalf("LoadWithDefaultFromByteArray() after ToYAML() error = %v", err)
+	}
+	if err := parsed.Validate(); err != nil {
+		t.Fatalf("Validate() after round-trip error = %v", err)
+	}
+
+	if !configsEqual(original, parsed) {
+		t.Errorf("round-trip mismatch:\noriginal: %+v\nparsed:   %+v", original, parsed)
+	}
+}
+
+func TestToYAML_ContainsExpectedFields(t *testing.T) {
+	cfg := &Config{
+		Shared: SharedConfig{LookbackDays: 30, LookaheadDays: 45},
+		ReadFrom: ReadFromConfig{
+			GoogleCalendar: GoogleCalendarReadConfig{
+				CountryCode:        "vnm",
+				TodayIsFreezeDayIf: []map[string][]string{{anchorToday: {condNonBusiness}}},
+			},
+		},
+		WriteTo: WriteToConfig{
+			GoogleCalendar: GoogleCalendarWriteConfig{
+				ID: "myteam@group.calendar.google.com",
+				IfTodayIsFreezeDay: IfTodayIsFreezeDayConfig{
+					Default: DefaultConfig{
+						Summary:     helpers.StringPtr("Freeze"),
+						Description: helpers.StringPtr("No prod ops"),
+						StartTime:   helpers.StringPtr("09:00"),
+						EndTime:     helpers.StringPtr("18:00"),
+					},
+				},
+			},
+		},
+	}
+
+	yamlStr, err := cfg.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error = %v", err)
+	}
+
+	checks := []string{
+		"lookbackDays: 30",
+		"lookaheadDays: 45",
+		"countryCode: vnm",
+		"myteam@group.calendar.google.com",
+		"startTime:",
+		"09:00",
+		"endTime:",
+		"18:00",
+	}
+	for _, want := range checks {
+		if !strings.Contains(yamlStr, want) {
+			t.Errorf("ToYAML() output missing %q\ngot:\n%s", want, yamlStr)
+		}
+	}
+}

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -131,6 +131,12 @@ func (c *Config) SetDefaultAndValidateWriteToGoogleCalendarIfTodayIsFreezeDay() 
 		return fmt.Errorf("writeTo.googleCalendar.ifTodayIsFreezeDay.default.description cannot be longer than 8000 characters")
 	}
 
+	// All-day events do not use startTime/endTime — skip time validation.
+	allDay := c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.AllDay
+	if allDay != nil && *allDay {
+		return nil
+	}
+
 	startT, err := parseHHMM(*c.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime)
 	if err != nil {
 		return fmt.Errorf("writeTo.googleCalendar.ifTodayIsFreezeDay.default.startTime: %w", err)

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -49,7 +49,22 @@ func configsEqual(a, b *Config) bool {
 		return false
 	}
 
+	if !boolPtrsEqual(aDefault.AllDay, bDefault.AllDay) {
+		return false
+	}
+
 	return true
+}
+
+// boolPtrsEqual compares two bool pointers by their values
+func boolPtrsEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // stringPtrsEqual compares two string pointers by their values
@@ -71,6 +86,7 @@ func Test_ConfigValidate(t *testing.T) {
 	}{
 		{name: "valid", yaml: mockConfigYamlValid, want: mockValidParsedConfig},
 		{name: "valid_custom_times", yaml: mockConfigYamlCustomTimes, want: mockCustomTimesParsedConfig},
+		{name: "valid_all_day", yaml: mockConfigYamlAllDay, want: mockAllDayParsedConfig},
 		{name: "invalid_countryCode", yaml: mockConfigYamlInvalidCountryCode, want: nil},
 		{name: "invalid_unsupportedDate", yaml: mockConfigYamlInvalidUnsupportedDate, want: nil},
 		{name: "invalid_unsupportedCheck", yaml: mockConfigYamlInvalidUnsupportedCheck, want: nil},

--- a/internal/config/config_validate_testdata.go
+++ b/internal/config/config_validate_testdata.go
@@ -2,6 +2,14 @@ package config
 
 import "github.com/nvat/tgifreezeday/internal/helpers"
 
+// testAnchorToday and testCondNonBusiness are shared constants used across
+// test data and test files in this package to avoid goconst threshold violations.
+const (
+	testAnchorToday     = "today"
+	testAnchorTomorrow  = "tomorrow"
+	testCondNonBusiness = "isNonBusinessDay"
+)
+
 const mockConfigYamlValid = `
 shared:
   lookbackDays: 20
@@ -35,13 +43,13 @@ var mockValidParsedConfig = &Config{
 			CountryCode: "jpn",
 			TodayIsFreezeDayIf: []map[string][]string{
 				{
-					"today": []string{"isTheFirstBusinessDayOfTheMonth"},
+					testAnchorToday: []string{"isTheFirstBusinessDayOfTheMonth"},
 				},
 				{
-					"today": []string{"isTheLastBusinessDayOfTheMonth"},
+					testAnchorToday: []string{"isTheLastBusinessDayOfTheMonth"},
 				},
 				{
-					"tomorrow": []string{"isNonBusinessDay"},
+					testAnchorTomorrow: []string{"isNonBusinessDay"},
 				},
 			},
 		},
@@ -133,7 +141,7 @@ var mockCustomTimesParsedConfig = &Config{
 		GoogleCalendar: GoogleCalendarReadConfig{
 			CountryCode: "jpn",
 			TodayIsFreezeDayIf: []map[string][]string{
-				{"today": []string{"isTheFirstBusinessDayOfTheMonth"}},
+				{testAnchorToday: []string{"isTheFirstBusinessDayOfTheMonth"}},
 			},
 		},
 	},
@@ -227,6 +235,51 @@ writeTo:
         startTime: "10:00"
         endTime: "10:00"
 `
+
+const mockConfigYamlAllDay = `
+shared:
+  lookbackDays: 20
+  lookaheadDays: 60
+readFrom:
+  googleCalendar:
+    countryCode: "jpn"
+    todayIsFreezeDayIf:
+      - today:
+        - isTheFirstBusinessDayOfTheMonth
+writeTo:
+  googleCalendar:
+    id: "example-freeze@example.com"
+    ifTodayIsFreezeDay:
+      default:
+        allDay: true
+`
+
+var mockAllDayParsedConfig = &Config{
+	Shared: SharedConfig{
+		LookbackDays:  20,
+		LookaheadDays: 60,
+	},
+	ReadFrom: ReadFromConfig{
+		GoogleCalendar: GoogleCalendarReadConfig{
+			CountryCode: "jpn",
+			TodayIsFreezeDayIf: []map[string][]string{
+				{testAnchorToday: []string{"isTheFirstBusinessDayOfTheMonth"}},
+			},
+		},
+	},
+	WriteTo: WriteToConfig{
+		GoogleCalendar: GoogleCalendarWriteConfig{
+			ID: "example-freeze@example.com",
+			IfTodayIsFreezeDay: IfTodayIsFreezeDayConfig{
+				Default: DefaultConfig{
+					Summary:     helpers.StringPtr("Today is FREEZE-DAY. no PROD operation is allowed."),
+					Description: helpers.StringPtr("Managed by tgifreezeday, do not modify."),
+					AllDay:      helpers.BoolPtr(true),
+				},
+			},
+		},
+	},
+}
 
 const mockConfigYamlInvalidUnsupportedCheck = `
 shared:

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -7,5 +7,5 @@ import (
 type TGIFCalendarRepository interface {
 	GetFreezeDaysInRange(rangeStart, rangeEnd time.Time) (*TGIFMapping, error)
 	WipeAllBlockersInRange(startDate, endDate time.Time) error
-	WriteBlockerOnDate(date time.Time, summary, description, startTime, endTime string) error
+	WriteBlockerOnDate(date time.Time, summary, description, startTime, endTime string, allDay bool) error
 }

--- a/internal/domain/sync.go
+++ b/internal/domain/sync.go
@@ -14,6 +14,7 @@ func RunSync(
 	rangeStart, rangeEnd time.Time,
 	rules TodayIsFreezeDayIf,
 	summary, description, startTime, endTime string,
+	allDay bool,
 ) (string, bool) {
 	tgifMapping, err := repo.GetFreezeDaysInRange(rangeStart, rangeEnd)
 	if err != nil {
@@ -25,7 +26,7 @@ func RunSync(
 	count := 0
 	for _, day := range *tgifMapping {
 		if day.IsTodayFreezeDay(rules) {
-			if err := repo.WriteBlockerOnDate(day.Date, summary, description, startTime, endTime); err != nil {
+			if err := repo.WriteBlockerOnDate(day.Date, summary, description, startTime, endTime, allDay); err != nil {
 				return fmt.Sprintf("failed to write blocker on %s: %s", day.Date.Format("2006-01-02"), err.Error()), true
 			}
 			count++

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -134,15 +134,23 @@ func (s *Scheduler) runSync(ctx context.Context, cfg *db.Config) (string, bool) 
 	if err != nil {
 		return err.Error(), true
 	}
+	d := appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default
+	allDay := d.AllDay != nil && *d.AllDay
+	startTime, endTime := "", ""
+	if !allDay {
+		startTime = *d.StartTime
+		endTime = *d.EndTime
+	}
 	rangeStart, rangeEnd := syncDateRange(appCfg.Shared.LookbackDays, appCfg.Shared.LookaheadDays)
 	return domain.RunSync(
 		repo,
 		rangeStart, rangeEnd,
 		domain.TodayIsFreezeDayIf(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf),
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary,
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description,
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime,
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime,
+		*d.Summary,
+		*d.Description,
+		startTime,
+		endTime,
+		allDay,
 	)
 }
 

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -1233,14 +1233,18 @@ func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string
 
 	// Calendar card — show friendly name when available.
 	calID := appCfg.WriteTo.GoogleCalendar.ID
-	calDisplay := html.EscapeString(calID)
+	var calDisplay string
 	if calendarName != "" {
-		calDisplay = fmt.Sprintf("%s (%s)", html.EscapeString(calendarName), html.EscapeString(calID))
+		calDisplay = `<strong>` + html.EscapeString(calendarName) + `</strong>` +
+			`<div style="font-size:0.8rem;color:var(--pico-muted-color);word-break:break-all;margin-top:0.2rem">` + html.EscapeString(calID) + `</div>`
+	} else {
+		calDisplay = `<span style="color:var(--pico-muted-color);font-size:0.85rem">(name unavailable)</span>` +
+			`<div style="font-size:0.8rem;color:var(--pico-muted-color);word-break:break-all;margin-top:0.2rem">` + html.EscapeString(calID) + `</div>`
 	}
 	calendarCard := fmt.Sprintf(`
 <div class="detail-card">
   <h4>Target Calendar</h4>
-  <div class="detail-field"><div class="val" style="word-break:break-all">%s</div></div>
+  <div class="detail-field"><div class="val">%s</div></div>
 </div>`, calDisplay)
 
 	// Blocker event card
@@ -1333,10 +1337,12 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
 	allDayChecked := ""
 	timeFieldsStyle := ""
 	timeRequired := " required"
+	timeDisabled := ""
 	if data.AllDay {
 		allDayChecked = " checked"
-		timeFieldsStyle = `style="display:none"`
+		timeFieldsStyle = `style="opacity:0.4;pointer-events:none"`
 		timeRequired = ""
+		timeDisabled = " disabled"
 	}
 
 	autoSyncPicker := fmt.Sprintf(`
@@ -1451,17 +1457,20 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
       <textarea id="event_description" name="event_description" rows="4" maxlength="8000" placeholder="Production operations restricted today.">%s</textarea>
       <small style="color:var(--pico-muted-color)">HTML supported: &lt;br&gt;, &lt;ul&gt;&lt;li&gt;, &lt;a href=""&gt;, &lt;strong&gt;, &lt;em&gt;. Max 8000 characters.</small>
     </label>
-    <label style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.75rem;cursor:pointer">
-      <input type="checkbox" id="all_day" name="all_day" onchange="toggleAllDay(this)"%s style="margin:0;width:auto">
-      All-day event
-    </label>
+    <div style="margin-bottom:1rem">
+      <label style="display:flex;align-items:center;gap:0.6rem;cursor:pointer;font-weight:500">
+        <input type="checkbox" id="all_day" name="all_day" onchange="toggleAllDay(this)" style="width:1.1rem;height:1.1rem;cursor:pointer"%s>
+        All-day event
+      </label>
+      <small style="color:var(--pico-muted-color);display:block;margin-top:0.25rem">Creates a full-day calendar event instead of a timed one</small>
+    </div>
     <div id="time-fields" %s>
-      <div class="two-col">
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
         <label for="start_time">Start time
-          <input type="time" id="start_time" name="start_time" value="%s"%s>
+          <input type="time" id="start_time" name="start_time" value="%s"%s%s>
         </label>
         <label for="end_time">End time
-          <input type="time" id="end_time" name="end_time" value="%s"%s>
+          <input type="time" id="end_time" name="end_time" value="%s"%s%s>
         </label>
       </div>
     </div>
@@ -1562,19 +1571,29 @@ function removeCond(gi, ci) {
 }
 
 function toggleAllDay(cb) {
-  var tf = document.getElementById('time-fields');
-  var st = document.getElementById('start_time');
-  var et = document.getElementById('end_time');
+  var container = document.getElementById('time-fields');
+  var inputs = container.querySelectorAll('input[type=time]');
   if (cb.checked) {
-    tf.style.display = 'none';
-    st.removeAttribute('required');
-    et.removeAttribute('required');
+    container.style.opacity = '0.4';
+    container.style.pointerEvents = 'none';
+    inputs.forEach(function(inp) {
+      inp.disabled = true;
+      inp.removeAttribute('required');
+    });
   } else {
-    tf.style.display = '';
-    st.setAttribute('required', '');
-    et.setAttribute('required', '');
+    container.style.opacity = '1';
+    container.style.pointerEvents = '';
+    inputs.forEach(function(inp) {
+      inp.disabled = false;
+      inp.setAttribute('required', '');
+    });
   }
 }
+
+document.addEventListener('DOMContentLoaded', function() {
+  var cb = document.getElementById('all_day');
+  if (cb && cb.checked) toggleAllDay(cb);
+});
 
 document.getElementById('config-form').addEventListener('submit', function() {
   document.getElementById('rules_json').value = JSON.stringify(rules);
@@ -1603,8 +1622,10 @@ renderRules();
 		allDayChecked,
 		timeFieldsStyle,
 		html.EscapeString(data.StartTime),
+		timeDisabled,
 		timeRequired,
 		html.EscapeString(data.EndTime),
+		timeDisabled,
 		timeRequired,
 		autoSyncPicker,
 		deleteBtn,

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -31,6 +31,9 @@ var jstDisplay = scheduler.JST
 const (
 	countryCodeJPN = "jpn"
 	countryCodeVNM = "vnm"
+
+	ruleAnchorToday    = "today"
+	ruleAnchorTomorrow = "tomorrow"
 )
 
 type ConfigHandler struct {
@@ -152,8 +155,21 @@ func (h *ConfigHandler) HandleDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	role := roleFromContext(r.Context())
+
+	// Resolve a human-readable calendar name for the detail view.
+	calendarName := ""
+	if appCfg, parseErr := appconfig.LoadWithDefaultFromByteArray([]byte(cfg.ConfigYAML)); parseErr == nil {
+		calID := appCfg.WriteTo.GoogleCalendar.ID
+		for _, cal := range h.fetchCalendars(r.Context(), user.ID) {
+			if cal.ID == calID {
+				calendarName = cal.Summary
+				break
+			}
+		}
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, configDetailHTML(h.basePath, cfg, user.ID, role)) //nolint:errcheck
+	fmt.Fprint(w, configDetailHTML(h.basePath, cfg, user.ID, role, calendarName)) //nolint:errcheck
 }
 
 // HandleEdit renders the config edit form pre-populated.
@@ -504,15 +520,23 @@ func (h *ConfigHandler) runSync(ctx context.Context, userID int64, cfg *db.Confi
 	if err != nil {
 		return err.Error(), true
 	}
+	d := appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default
+	allDay := d.AllDay != nil && *d.AllDay
+	startTime, endTime := "", ""
+	if !allDay {
+		startTime = *d.StartTime
+		endTime = *d.EndTime
+	}
 	rangeStart, rangeEnd := dateRange(appCfg.Shared.LookbackDays, appCfg.Shared.LookaheadDays)
 	return domain.RunSync(
 		repo,
 		rangeStart, rangeEnd,
 		domain.TodayIsFreezeDayIf(appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf),
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary,
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Description,
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.StartTime,
-		*appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.EndTime,
+		*d.Summary,
+		*d.Description,
+		startTime,
+		endTime,
+		allDay,
 	)
 }
 
@@ -541,7 +565,6 @@ type blockerItem struct {
 // configFormData holds the structured fields for the config create/edit form.
 type configFormData struct {
 	Name          string
-	SchemaVersion string
 	LookbackDays  int
 	LookaheadDays int
 	CountryCode   string
@@ -550,6 +573,7 @@ type configFormData struct {
 	Description   string
 	StartTime     string
 	EndTime       string
+	AllDay        bool
 	SyncSchedule  string
 	// Rules is the todayIsFreezeDayIf slice — each map has exactly one key (anchor) → conditions.
 	Rules []map[string][]string
@@ -563,7 +587,6 @@ type formRule struct {
 
 func defaultFormData() configFormData {
 	return configFormData{
-		SchemaVersion: appconfig.CurrentSchemaVersion,
 		LookbackDays:  20,
 		LookaheadDays: 60,
 		CountryCode:   countryCodeJPN,
@@ -571,11 +594,12 @@ func defaultFormData() configFormData {
 		Description:   "Production operations restricted today.",
 		StartTime:     "08:00",
 		EndTime:       "20:00",
+		AllDay:        false,
 		SyncSchedule:  db.SyncScheduleNone,
 		Rules: []map[string][]string{
-			{"today": {"isTheFirstBusinessDayOfTheMonth"}},
-			{"today": {"isTheLastBusinessDayOfTheMonth"}},
-			{"tomorrow": {"isNonBusinessDay"}},
+			{ruleAnchorToday: {"isTheFirstBusinessDayOfTheMonth"}},
+			{ruleAnchorToday: {"isTheLastBusinessDayOfTheMonth"}},
+			{ruleAnchorTomorrow: {"isNonBusinessDay"}},
 		},
 	}
 }
@@ -584,7 +608,6 @@ func defaultFormData() configFormData {
 func configToFormData(cfg *db.Config, appCfg *appconfig.Config) configFormData {
 	data := configFormData{
 		Name:          cfg.Name,
-		SchemaVersion: cfg.SchemaVersion,
 		SyncSchedule:  cfg.SyncSchedule,
 		LookbackDays:  appCfg.Shared.LookbackDays,
 		LookaheadDays: appCfg.Shared.LookaheadDays,
@@ -604,6 +627,9 @@ func configToFormData(cfg *db.Config, appCfg *appconfig.Config) configFormData {
 	}
 	if d.EndTime != nil {
 		data.EndTime = *d.EndTime
+	}
+	if d.AllDay != nil {
+		data.AllDay = *d.AllDay
 	}
 	return data
 }
@@ -640,10 +666,18 @@ func formToAppConfig(r *http.Request) (*appconfig.Config, error) {
 
 	summary := r.FormValue("event_summary")
 	description := r.FormValue("event_description")
-	startTime := r.FormValue("start_time")
-	endTime := r.FormValue("end_time")
 	calendarID := r.FormValue("write_calendar_id")
 	countryCode := r.FormValue("country_code")
+	allDay := r.FormValue("all_day") == "on"
+
+	var allDayPtr *bool
+	var startTimePtr, endTimePtr *string
+	if allDay {
+		allDayPtr = helpers.BoolPtr(true)
+	} else {
+		startTimePtr = helpers.StringPtr(r.FormValue("start_time"))
+		endTimePtr = helpers.StringPtr(r.FormValue("end_time"))
+	}
 
 	cfg := &appconfig.Config{
 		Shared: appconfig.SharedConfig{
@@ -663,8 +697,9 @@ func formToAppConfig(r *http.Request) (*appconfig.Config, error) {
 					Default: appconfig.DefaultConfig{
 						Summary:     helpers.StringPtr(summary),
 						Description: helpers.StringPtr(description),
-						StartTime:   helpers.StringPtr(startTime),
-						EndTime:     helpers.StringPtr(endTime),
+						StartTime:   startTimePtr,
+						EndTime:     endTimePtr,
+						AllDay:      allDayPtr,
 					},
 				},
 			},
@@ -701,7 +736,6 @@ func formDataFromRequest(r *http.Request) configFormData {
 		rules = defaultFormData().Rules
 	}
 	return configFormData{
-		SchemaVersion: appconfig.CurrentSchemaVersion,
 		LookbackDays:  lookback,
 		LookaheadDays: lookahead,
 		CountryCode:   r.FormValue("country_code"),
@@ -710,6 +744,7 @@ func formDataFromRequest(r *http.Request) configFormData {
 		Description:   r.FormValue("event_description"),
 		StartTime:     r.FormValue("start_time"),
 		EndTime:       r.FormValue("end_time"),
+		AllDay:        r.FormValue("all_day") == "on",
 		Rules:         rules,
 	}
 }
@@ -950,7 +985,7 @@ func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
 		cfg.ID, syncScheduleOptions(cfg.SyncSchedule))
 }
 
-func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role perm.Role) string {
+func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role perm.Role, calendarName string) string {
 	badge := statusBadgeHTML(cfg.Status, cfg.StatusMessage)
 	escapedName := html.EscapeString(cfg.Name)
 	escapedSchema := html.EscapeString(cfg.SchemaVersion)
@@ -1015,7 +1050,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 	autoSyncTrigger := autoSyncTriggerHTML(cfg, canEdit)
 
 	// Build human-readable config detail cards.
-	configCardsHTML := configDetailCardsHTML(cfg.ConfigYAML)
+	configCardsHTML := configDetailCardsHTML(cfg.ConfigYAML, calendarName)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -1142,7 +1177,8 @@ func countryLabel(code string) string {
 
 // configDetailCardsHTML renders human-readable detail cards from the stored YAML.
 // Falls back to a raw YAML display if parsing fails.
-func configDetailCardsHTML(yamlContent string) string {
+// calendarName is the human-readable name for the write calendar (empty string = show ID only).
+func configDetailCardsHTML(yamlContent, calendarName string) string {
 	appCfg, err := appconfig.LoadWithDefaultFromByteArray([]byte(yamlContent))
 	if err != nil {
 		return fmt.Sprintf(`<div class="detail-card"><h4>Config (parse error)</h4><pre style="white-space:pre-wrap;font-size:0.84rem">%s</pre></div>`,
@@ -1188,23 +1224,29 @@ func configDetailCardsHTML(yamlContent string) string {
   %s
 </div>`, rulesSB.String())
 
-	// Calendar card
+	// Calendar card — show friendly name when available.
+	calID := appCfg.WriteTo.GoogleCalendar.ID
+	calDisplay := html.EscapeString(calID)
+	if calendarName != "" {
+		calDisplay = fmt.Sprintf("%s (%s)", html.EscapeString(calendarName), html.EscapeString(calID))
+	}
 	calendarCard := fmt.Sprintf(`
 <div class="detail-card">
   <h4>Target Calendar</h4>
-  <div class="detail-field"><label>Calendar ID</label><div class="val" style="word-break:break-all">%s</div></div>
-</div>`, html.EscapeString(appCfg.WriteTo.GoogleCalendar.ID))
+  <div class="detail-field"><div class="val" style="word-break:break-all">%s</div></div>
+</div>`, calDisplay)
 
 	// Blocker event card
-	summary := ""
-	description := ""
+	evSummary := ""
+	evDescription := ""
 	startTime := ""
 	endTime := ""
+	isAllDay := d.AllDay != nil && *d.AllDay
 	if d.Summary != nil {
-		summary = *d.Summary
+		evSummary = *d.Summary
 	}
 	if d.Description != nil {
-		description = *d.Description
+		evDescription = *d.Description
 	}
 	if d.StartTime != nil {
 		startTime = *d.StartTime
@@ -1212,20 +1254,26 @@ func configDetailCardsHTML(yamlContent string) string {
 	if d.EndTime != nil {
 		endTime = *d.EndTime
 	}
+	var timingHTML string
+	if isAllDay {
+		timingHTML = `<div class="detail-field"><label>Timing</label><div class="val">All-day event</div></div>`
+	} else {
+		timingHTML = fmt.Sprintf(`
+  <div class="detail-row">
+    <div class="detail-field"><label>Start</label><div class="val">%s</div></div>
+    <div class="detail-field"><label>End</label><div class="val">%s</div></div>
+  </div>`, html.EscapeString(startTime), html.EscapeString(endTime))
+	}
 	eventCard := fmt.Sprintf(`
 <div class="detail-card">
   <h4>Blocker Event</h4>
   <div class="detail-field" style="margin-bottom:0.5rem"><label>Summary</label><div class="val">%s</div></div>
   <div class="detail-field" style="margin-bottom:0.5rem"><label>Description</label><div class="val" style="font-size:0.85rem;white-space:pre-wrap">%s</div></div>
-  <div class="detail-row">
-    <div class="detail-field"><label>Start</label><div class="val">%s</div></div>
-    <div class="detail-field"><label>End</label><div class="val">%s</div></div>
-  </div>
+  %s
 </div>`,
-		html.EscapeString(summary),
-		html.EscapeString(description),
-		html.EscapeString(startTime),
-		html.EscapeString(endTime))
+		html.EscapeString(evSummary),
+		html.EscapeString(evDescription),
+		timingHTML)
 
 	return dateRangeCard + holidayCard + freezeCard + calendarCard + eventCard
 }
@@ -1275,14 +1323,14 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
 
 	calPicker := calendarPickerHTML(cals, data.CalendarID)
 
-	schemaPicker := fmt.Sprintf(`
-<div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:1rem">
-  <span style="font-size:0.88rem;color:var(--pico-muted-color)">Schema: <strong>%s</strong></span>
-  <a href="`+basePath+`/schema/%s" target="_blank" title="View schema reference" style="font-size:1rem;text-decoration:none">ℹ️</a>
-</div>`,
-		html.EscapeString(data.SchemaVersion),
-		html.EscapeString(data.SchemaVersion),
-	)
+	allDayChecked := ""
+	timeFieldsStyle := ""
+	timeRequired := " required"
+	if data.AllDay {
+		allDayChecked = " checked"
+		timeFieldsStyle = `style="display:none"`
+		timeRequired = ""
+	}
 
 	autoSyncPicker := fmt.Sprintf(`
 <label for="sync_schedule">Auto-Sync
@@ -1355,7 +1403,6 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
     <label for="name">Config Name
       <input type="text" id="name" name="name" value="%s" placeholder="e.g. Japan prod freeze" required>
     </label>
-    %s
 
     <div class="section-header">Date Range</div>
     <div class="two-col">
@@ -1397,13 +1444,19 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
       <textarea id="event_description" name="event_description" rows="4" maxlength="8000" placeholder="Production operations restricted today.">%s</textarea>
       <small style="color:var(--pico-muted-color)">HTML supported: &lt;br&gt;, &lt;ul&gt;&lt;li&gt;, &lt;a href=""&gt;, &lt;strong&gt;, &lt;em&gt;. Max 8000 characters.</small>
     </label>
-    <div class="two-col">
-      <label for="start_time">Start time
-        <input type="time" id="start_time" name="start_time" value="%s" required>
-      </label>
-      <label for="end_time">End time
-        <input type="time" id="end_time" name="end_time" value="%s" required>
-      </label>
+    <label style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.75rem;cursor:pointer">
+      <input type="checkbox" id="all_day" name="all_day" onchange="toggleAllDay(this)"%s style="margin:0;width:auto">
+      All-day event
+    </label>
+    <div id="time-fields" %s>
+      <div class="two-col">
+        <label for="start_time">Start time
+          <input type="time" id="start_time" name="start_time" value="%s"%s>
+        </label>
+        <label for="end_time">End time
+          <input type="time" id="end_time" name="end_time" value="%s"%s>
+        </label>
+      </div>
     </div>
 
     <div class="section-header">Auto-Sync</div>
@@ -1501,6 +1554,21 @@ function removeCond(gi, ci) {
   renderRules();
 }
 
+function toggleAllDay(cb) {
+  var tf = document.getElementById('time-fields');
+  var st = document.getElementById('start_time');
+  var et = document.getElementById('end_time');
+  if (cb.checked) {
+    tf.style.display = 'none';
+    st.removeAttribute('required');
+    et.removeAttribute('required');
+  } else {
+    tf.style.display = '';
+    st.setAttribute('required', '');
+    et.setAttribute('required', '');
+  }
+}
+
 document.getElementById('config-form').addEventListener('submit', function() {
   document.getElementById('rules_json').value = JSON.stringify(rules);
 });
@@ -1518,7 +1586,6 @@ renderRules();
 		errHTML,
 		html.EscapeString(action),
 		html.EscapeString(data.Name),
-		schemaPicker,
 		data.LookbackDays,
 		data.LookaheadDays,
 		countryOptions,
@@ -1526,8 +1593,12 @@ renderRules();
 		html.EscapeString(data.CalendarID),
 		html.EscapeString(data.Summary),
 		html.EscapeString(data.Description),
+		allDayChecked,
+		timeFieldsStyle,
 		data.StartTime,
+		timeRequired,
 		data.EndTime,
+		timeRequired,
 		autoSyncPicker,
 		deleteBtn,
 		html.EscapeString(backURL),

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -156,9 +156,11 @@ func (h *ConfigHandler) HandleDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	role := roleFromContext(r.Context())
 
-	// Resolve a human-readable calendar name for the detail view.
+	// Parse once; resolve calendar name from the result.
+	var parsedCfg *appconfig.Config
 	calendarName := ""
 	if appCfg, parseErr := appconfig.LoadWithDefaultFromByteArray([]byte(cfg.ConfigYAML)); parseErr == nil {
+		parsedCfg = appCfg
 		calID := appCfg.WriteTo.GoogleCalendar.ID
 		for _, cal := range h.fetchCalendars(r.Context(), user.ID) {
 			if cal.ID == calID {
@@ -169,7 +171,7 @@ func (h *ConfigHandler) HandleDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, configDetailHTML(h.basePath, cfg, user.ID, role, calendarName)) //nolint:errcheck
+	fmt.Fprint(w, configDetailHTML(h.basePath, cfg, user.ID, role, parsedCfg, calendarName)) //nolint:errcheck
 }
 
 // HandleEdit renders the config edit form pre-populated.
@@ -706,6 +708,9 @@ func formToAppConfig(r *http.Request) (*appconfig.Config, error) {
 		},
 	}
 	cfg.SetDefault()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	return cfg, nil
 }
 
@@ -717,7 +722,10 @@ func rulesToJSON(rules []map[string][]string) string {
 			jsRules = append(jsRules, formRule{Anchor: anchor, Conditions: conditions})
 		}
 	}
-	b, _ := json.Marshal(jsRules) //nolint:errcheck
+	b, err := json.Marshal(jsRules)
+	if err != nil {
+		return "[]"
+	}
 	return string(b)
 }
 
@@ -985,7 +993,7 @@ func autoSyncModalHTML(basePath string, cfg *db.Config, canEdit bool) string {
 		cfg.ID, syncScheduleOptions(cfg.SyncSchedule))
 }
 
-func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role perm.Role, calendarName string) string {
+func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role perm.Role, appCfg *appconfig.Config, calendarName string) string {
 	badge := statusBadgeHTML(cfg.Status, cfg.StatusMessage)
 	escapedName := html.EscapeString(cfg.Name)
 	escapedSchema := html.EscapeString(cfg.SchemaVersion)
@@ -1050,7 +1058,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 	autoSyncTrigger := autoSyncTriggerHTML(cfg, canEdit)
 
 	// Build human-readable config detail cards.
-	configCardsHTML := configDetailCardsHTML(cfg.ConfigYAML, calendarName)
+	configCardsHTML := configDetailCardsHTML(appCfg, calendarName)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -1159,6 +1167,7 @@ func conditionLabel(c string) string {
 	case "isNonBusinessDay":
 		return "non-business day (weekend / holiday)"
 	default:
+		// return raw key for forward-compat — add labels here when adding new conditions
 		return c
 	}
 }
@@ -1175,14 +1184,12 @@ func countryLabel(code string) string {
 	}
 }
 
-// configDetailCardsHTML renders human-readable detail cards from the stored YAML.
-// Falls back to a raw YAML display if parsing fails.
+// configDetailCardsHTML renders human-readable detail cards from the parsed config.
+// Falls back to a generic parse-error notice when appCfg is nil.
 // calendarName is the human-readable name for the write calendar (empty string = show ID only).
-func configDetailCardsHTML(yamlContent, calendarName string) string {
-	appCfg, err := appconfig.LoadWithDefaultFromByteArray([]byte(yamlContent))
-	if err != nil {
-		return fmt.Sprintf(`<div class="detail-card"><h4>Config (parse error)</h4><pre style="white-space:pre-wrap;font-size:0.84rem">%s</pre></div>`,
-			html.EscapeString(err.Error()))
+func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string {
+	if appCfg == nil {
+		return `<div class="detail-card"><h4>Config (parse error)</h4><p style="font-size:0.84rem;color:var(--pico-muted-color)">Could not parse config YAML.</p></div>`
 	}
 
 	d := appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default
@@ -1595,9 +1602,9 @@ renderRules();
 		html.EscapeString(data.Description),
 		allDayChecked,
 		timeFieldsStyle,
-		data.StartTime,
+		html.EscapeString(data.StartTime),
 		timeRequired,
-		data.EndTime,
+		html.EscapeString(data.EndTime),
 		timeRequired,
 		autoSyncPicker,
 		deleteBtn,

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nvat/tgifreezeday/internal/adapter/googlecalendar"
 	appconfig "github.com/nvat/tgifreezeday/internal/config"
 	"github.com/nvat/tgifreezeday/internal/domain"
+	"github.com/nvat/tgifreezeday/internal/helpers"
 	"github.com/nvat/tgifreezeday/internal/logging"
 	"github.com/nvat/tgifreezeday/internal/perm"
 	"github.com/nvat/tgifreezeday/internal/scheduler"
@@ -26,6 +27,11 @@ var log = logging.GetLogger()
 
 // jstDisplay aliases scheduler.JST for formatting timestamps in the UI.
 var jstDisplay = scheduler.JST
+
+const (
+	countryCodeJPN = "jpn"
+	countryCodeVNM = "vnm"
+)
 
 type ConfigHandler struct {
 	configs     *db.ConfigStore
@@ -72,9 +78,8 @@ func (h *ConfigHandler) HandleNew(w http.ResponseWriter, r *http.Request) {
 	}
 	user := userFromContext(r.Context())
 	cals := h.fetchCalendars(r.Context(), user.ID)
-	schemaYAML, _ := appconfig.SchemaYAML(appconfig.CurrentSchemaVersion)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, configFormHTML("New Config", h.basePath+"/configs", h.basePath+"/dashboard", appconfig.CurrentSchemaVersion, "", "", string(schemaYAML), "", false, db.SyncScheduleNone, cals, h.basePath)) //nolint:errcheck
+	fmt.Fprint(w, configFormHTML("New Config", h.basePath+"/configs", h.basePath+"/dashboard", defaultFormData(), "", false, cals, h.basePath)) //nolint:errcheck
 }
 
 // HandleCreate processes the config creation form.
@@ -90,14 +95,30 @@ func (h *ConfigHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := r.FormValue("name")
-	yamlContent := r.FormValue("config_yaml")
 	syncSchedule := parseSyncSchedule(r.FormValue("sync_schedule"))
 
-	if name == "" {
+	renderFormErr := func(formErr string) {
 		cals := h.fetchCalendars(r.Context(), user.ID)
-		schemaYAML, _ := appconfig.SchemaYAML(appconfig.CurrentSchemaVersion)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprint(w, configFormHTML("New Config", h.basePath+"/configs", h.basePath+"/dashboard", appconfig.CurrentSchemaVersion, name, yamlContent, string(schemaYAML), "Name is required.", false, syncSchedule, cals, h.basePath)) //nolint:errcheck
+		fd := formDataFromRequest(r)
+		fd.Name = name
+		fd.SyncSchedule = syncSchedule
+		fmt.Fprint(w, configFormHTML("New Config", h.basePath+"/configs", h.basePath+"/dashboard", fd, formErr, false, cals, h.basePath)) //nolint:errcheck
+	}
+
+	if name == "" {
+		renderFormErr("Name is required.")
+		return
+	}
+
+	appCfg, err := formToAppConfig(r)
+	if err != nil {
+		renderFormErr(err.Error())
+		return
+	}
+	yamlContent, err := appCfg.ToYAML()
+	if err != nil {
+		renderFormErr("Failed to build config: " + err.Error())
 		return
 	}
 
@@ -153,11 +174,21 @@ func (h *ConfigHandler) HandleEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cals := h.fetchCalendars(r.Context(), user.ID)
-	schemaYAML, _ := appconfig.SchemaYAML(cfg.SchemaVersion)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	action := fmt.Sprintf(h.basePath+"/configs/%d", id)
 	backURL := fmt.Sprintf(h.basePath+"/configs/%d", id)
-	fmt.Fprint(w, configFormHTML("Edit Config", action, backURL, cfg.SchemaVersion, cfg.Name, cfg.ConfigYAML, string(schemaYAML), "", true, cfg.SyncSchedule, cals, h.basePath)) //nolint:errcheck
+
+	// Parse existing YAML to pre-populate the structured form; fall back to defaults on error.
+	var fd configFormData
+	appCfg, parseErr := h.parseAppConfig(cfg.ConfigYAML)
+	if parseErr != nil {
+		fd = defaultFormData()
+		fd.Name = cfg.Name
+		fd.SyncSchedule = cfg.SyncSchedule
+	} else {
+		fd = configToFormData(cfg, appCfg)
+	}
+	fmt.Fprint(w, configFormHTML("Edit Config", action, backURL, fd, "", true, cals, h.basePath)) //nolint:errcheck
 }
 
 // HandleUpdate processes the config edit form.
@@ -175,13 +206,7 @@ func (h *ConfigHandler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := r.FormValue("name")
-	yamlContent := r.FormValue("config_yaml")
 	syncSchedule := parseSyncSchedule(r.FormValue("sync_schedule"))
-
-	if name == "" {
-		httpError(w, http.StatusBadRequest, "name is required")
-		return
-	}
 
 	cfg, err := h.getConfig(r.Context(), id, user.ID)
 	if err != nil || cfg == nil {
@@ -190,6 +215,34 @@ func (h *ConfigHandler) HandleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if role := roleFromContext(r.Context()); !role.CanEditConfig(cfg.UserID, user.ID) {
 		httpError(w, http.StatusForbidden, "you do not have permission to edit this config")
+		return
+	}
+
+	action := fmt.Sprintf(h.basePath+"/configs/%d", id)
+	backURL := fmt.Sprintf(h.basePath+"/configs/%d", id)
+
+	renderFormErr := func(formErr string) {
+		cals := h.fetchCalendars(r.Context(), user.ID)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fd := formDataFromRequest(r)
+		fd.Name = name
+		fd.SyncSchedule = syncSchedule
+		fmt.Fprint(w, configFormHTML("Edit Config", action, backURL, fd, formErr, true, cals, h.basePath)) //nolint:errcheck
+	}
+
+	if name == "" {
+		renderFormErr("Name is required.")
+		return
+	}
+
+	appCfg, err := formToAppConfig(r)
+	if err != nil {
+		renderFormErr(err.Error())
+		return
+	}
+	yamlContent, err := appCfg.ToYAML()
+	if err != nil {
+		renderFormErr("Failed to build config: " + err.Error())
 		return
 	}
 
@@ -485,6 +538,182 @@ type blockerItem struct {
 	ID      string `json:"id"`
 }
 
+// configFormData holds the structured fields for the config create/edit form.
+type configFormData struct {
+	Name          string
+	SchemaVersion string
+	LookbackDays  int
+	LookaheadDays int
+	CountryCode   string
+	CalendarID    string
+	Summary       string
+	Description   string
+	StartTime     string
+	EndTime       string
+	SyncSchedule  string
+	// Rules is the todayIsFreezeDayIf slice — each map has exactly one key (anchor) → conditions.
+	Rules []map[string][]string
+}
+
+// formRule is the JSON shape used by the JS rules builder.
+type formRule struct {
+	Anchor     string   `json:"anchor"`
+	Conditions []string `json:"conditions"`
+}
+
+func defaultFormData() configFormData {
+	return configFormData{
+		SchemaVersion: appconfig.CurrentSchemaVersion,
+		LookbackDays:  20,
+		LookaheadDays: 60,
+		CountryCode:   countryCodeJPN,
+		Summary:       "🚫 PRODUCTION FREEZE - No Deployments",
+		Description:   "Production operations restricted today.",
+		StartTime:     "08:00",
+		EndTime:       "20:00",
+		SyncSchedule:  db.SyncScheduleNone,
+		Rules: []map[string][]string{
+			{"today": {"isTheFirstBusinessDayOfTheMonth"}},
+			{"today": {"isTheLastBusinessDayOfTheMonth"}},
+			{"tomorrow": {"isNonBusinessDay"}},
+		},
+	}
+}
+
+// configToFormData converts a stored config + its parsed appconfig into form data.
+func configToFormData(cfg *db.Config, appCfg *appconfig.Config) configFormData {
+	data := configFormData{
+		Name:          cfg.Name,
+		SchemaVersion: cfg.SchemaVersion,
+		SyncSchedule:  cfg.SyncSchedule,
+		LookbackDays:  appCfg.Shared.LookbackDays,
+		LookaheadDays: appCfg.Shared.LookaheadDays,
+		CountryCode:   appCfg.ReadFrom.GoogleCalendar.CountryCode,
+		CalendarID:    appCfg.WriteTo.GoogleCalendar.ID,
+		Rules:         appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf,
+	}
+	d := appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default
+	if d.Summary != nil {
+		data.Summary = *d.Summary
+	}
+	if d.Description != nil {
+		data.Description = *d.Description
+	}
+	if d.StartTime != nil {
+		data.StartTime = *d.StartTime
+	}
+	if d.EndTime != nil {
+		data.EndTime = *d.EndTime
+	}
+	return data
+}
+
+// formToAppConfig builds a Config from the structured form POST fields.
+func formToAppConfig(r *http.Request) (*appconfig.Config, error) {
+	lookbackDays, err := strconv.Atoi(r.FormValue("lookback_days"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid lookback_days: must be a number")
+	}
+	lookaheadDays, err := strconv.Atoi(r.FormValue("lookahead_days"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid lookahead_days: must be a number")
+	}
+
+	rulesJSON := r.FormValue("rules_json")
+	if rulesJSON == "" {
+		return nil, fmt.Errorf("freeze rules are required")
+	}
+	var jsRules []formRule
+	if err := json.Unmarshal([]byte(rulesJSON), &jsRules); err != nil {
+		return nil, fmt.Errorf("invalid rules_json: %w", err)
+	}
+	if len(jsRules) == 0 {
+		return nil, fmt.Errorf("at least one freeze rule group is required")
+	}
+	rules := make([]map[string][]string, 0, len(jsRules))
+	for _, jr := range jsRules {
+		if len(jr.Conditions) == 0 {
+			return nil, fmt.Errorf("each rule group must have at least one condition")
+		}
+		rules = append(rules, map[string][]string{jr.Anchor: jr.Conditions})
+	}
+
+	summary := r.FormValue("event_summary")
+	description := r.FormValue("event_description")
+	startTime := r.FormValue("start_time")
+	endTime := r.FormValue("end_time")
+	calendarID := r.FormValue("write_calendar_id")
+	countryCode := r.FormValue("country_code")
+
+	cfg := &appconfig.Config{
+		Shared: appconfig.SharedConfig{
+			LookbackDays:  lookbackDays,
+			LookaheadDays: lookaheadDays,
+		},
+		ReadFrom: appconfig.ReadFromConfig{
+			GoogleCalendar: appconfig.GoogleCalendarReadConfig{
+				CountryCode:        countryCode,
+				TodayIsFreezeDayIf: rules,
+			},
+		},
+		WriteTo: appconfig.WriteToConfig{
+			GoogleCalendar: appconfig.GoogleCalendarWriteConfig{
+				ID: calendarID,
+				IfTodayIsFreezeDay: appconfig.IfTodayIsFreezeDayConfig{
+					Default: appconfig.DefaultConfig{
+						Summary:     helpers.StringPtr(summary),
+						Description: helpers.StringPtr(description),
+						StartTime:   helpers.StringPtr(startTime),
+						EndTime:     helpers.StringPtr(endTime),
+					},
+				},
+			},
+		},
+	}
+	cfg.SetDefault()
+	return cfg, nil
+}
+
+// rulesToJSON converts the todayIsFreezeDayIf slice to the JSON used by the JS rules builder.
+func rulesToJSON(rules []map[string][]string) string {
+	jsRules := make([]formRule, 0, len(rules))
+	for _, r := range rules {
+		for anchor, conditions := range r {
+			jsRules = append(jsRules, formRule{Anchor: anchor, Conditions: conditions})
+		}
+	}
+	b, _ := json.Marshal(jsRules) //nolint:errcheck
+	return string(b)
+}
+
+// formDataFromRequest rebuilds a configFormData from posted form values (for re-rendering on error).
+func formDataFromRequest(r *http.Request) configFormData {
+	lookback, _ := strconv.Atoi(r.FormValue("lookback_days"))
+	lookahead, _ := strconv.Atoi(r.FormValue("lookahead_days"))
+	var rules []map[string][]string
+	var jsRules []formRule
+	if err := json.Unmarshal([]byte(r.FormValue("rules_json")), &jsRules); err == nil {
+		for _, jr := range jsRules {
+			rules = append(rules, map[string][]string{jr.Anchor: jr.Conditions})
+		}
+	}
+	if len(rules) == 0 {
+		rules = defaultFormData().Rules
+	}
+	return configFormData{
+		SchemaVersion: appconfig.CurrentSchemaVersion,
+		LookbackDays:  lookback,
+		LookaheadDays: lookahead,
+		CountryCode:   r.FormValue("country_code"),
+		CalendarID:    r.FormValue("write_calendar_id"),
+		Summary:       r.FormValue("event_summary"),
+		Description:   r.FormValue("event_description"),
+		StartTime:     r.FormValue("start_time"),
+		EndTime:       r.FormValue("end_time"),
+		Rules:         rules,
+	}
+}
+
 func (h *ConfigHandler) listBlockers(ctx context.Context, userID int64, cfg *db.Config) string {
 	appCfg, err := h.parseAppConfig(cfg.ConfigYAML)
 	if err != nil {
@@ -606,42 +835,31 @@ func actionResultHTML(action, msg string, isErr bool) string {
 </div>`, bg, border, color, html.EscapeString(action), html.EscapeString(msg))
 }
 
-func calendarOptions(cals []*googlecalendar.CalendarItem) string {
+// calendarPickerHTML renders an optional dropdown that fills the calendar ID field when selected.
+func calendarPickerHTML(cals []*googlecalendar.CalendarItem, selectedID string) string {
 	if len(cals) == 0 {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString(`<option value="">-- select to fill calendar ID in YAML --</option>`)
+	sb.WriteString(`<option value="">-- pick to fill ID below --</option>`)
 	for _, c := range cals {
-		fmt.Fprintf(&sb, `<option value="%s">%s</option>`,
-			html.EscapeString(c.ID), html.EscapeString(c.Summary+" ("+c.ID+")"))
+		sel := ""
+		if c.ID == selectedID {
+			sel = " selected"
+		}
+		fmt.Fprintf(&sb, `<option value="%s"%s>%s</option>`,
+			html.EscapeString(c.ID), sel,
+			html.EscapeString(c.Summary+" ("+c.ID+")"))
 	}
-	opts := sb.String()
 	return fmt.Sprintf(`
-<details style="margin-bottom:1rem">
-  <summary style="cursor:pointer;font-weight:600">📅 Pick target calendar</summary>
-  <div style="margin-top:0.75rem">
-    <select id="cal-picker" onchange="applyCalendarId(this.value)">
+<div style="display:flex;gap:0.5rem;align-items:flex-end;margin-bottom:0.25rem">
+  <div style="flex:1">
+    <label for="cal-picker" style="margin-bottom:0.25rem;font-size:0.88rem;color:var(--pico-muted-color)">Pick from writable calendars</label>
+    <select id="cal-picker" onchange="document.getElementById('write_calendar_id').value=this.value;this.value=''">
       %s
     </select>
-    <small style="display:block;margin-top:0.4rem;color:var(--pico-muted-color)">Selecting a calendar inserts its ID into the YAML below.</small>
   </div>
-</details>
-<script>
-function applyCalendarId(id) {
-  if (!id) return;
-  var safeId = JSON.stringify(id); // safely quoted, no injection
-  var re = /(writeTo[\s\S]*?googleCalendar[\s\S]*?id:\s*)["']?[^\n"']*["']?/;
-  if (window.cmEditor) {
-    var updated = window.cmEditor.getValue().replace(re, '$1' + safeId);
-    window.cmEditor.setValue(updated);
-  } else {
-    var ta = document.getElementById('config_yaml');
-    ta.value = ta.value.replace(re, '$1' + safeId);
-  }
-  document.getElementById('cal-picker').value = '';
-}
-</script>`, opts)
+</div>`, sb.String())
 }
 
 func autoSyncInfoHTML(cfg *db.Config) string {
@@ -736,7 +954,6 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 	badge := statusBadgeHTML(cfg.Status, cfg.StatusMessage)
 	escapedName := html.EscapeString(cfg.Name)
 	escapedSchema := html.EscapeString(cfg.SchemaVersion)
-	escapedYAML := html.EscapeString(cfg.ConfigYAML)
 	canSync := role.CanSyncConfig(cfg.UserID, currentUserID)
 	canEdit := role.CanEditConfig(cfg.UserID, currentUserID)
 	autoSyncEnabled := cfg.SyncSchedule != db.SyncScheduleNone
@@ -757,7 +974,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
       hx-swap="innerHTML"
       hx-on::before-request="document.getElementById('action-result').innerHTML='<p class=ack>🔍 Validating&#8230;</p>';document.getElementById('status-badge').innerHTML='<em class=ack>checking&#8230;</em>'"
       class="outline"
-      title="Re-check the config YAML and verify calendar write access">
+      title="Re-validate the config and verify calendar write access">
       🔍 Validate
     </button>`, cfg.ID)
 
@@ -797,6 +1014,9 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 
 	autoSyncTrigger := autoSyncTriggerHTML(cfg, canEdit)
 
+	// Build human-readable config detail cards.
+	configCardsHTML := configDetailCardsHTML(cfg.ConfigYAML)
+
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">
 <head>
@@ -805,13 +1025,9 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>%s &#8211; TGI Freeze Day</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/dracula.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism-tomorrow.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1/plugins/line-numbers/prism-line-numbers.min.css">
   <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js" defer></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/yaml/yaml.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1/prism.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1/plugins/line-numbers/prism-line-numbers.min.js" defer></script>
@@ -828,31 +1044,20 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
     .action-bar { display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:1.25rem; }
     .action-bar button, .action-bar a[role=button] { margin:0; padding:0.45rem 1rem; font-size:0.88rem; }
     .ack { opacity:0.65; font-style:italic; padding:0.5rem 0; font-size:0.9rem; }
-    .CodeMirror { height: auto; font-size: 0.88rem; line-height: 1.5; border: 1px solid var(--pico-card-border-color); border-radius: 0.5rem; }
-    .CodeMirror-cursor { display: none !important; }
-    pre[class*="language-"] { line-height: 1.5 !important; white-space: pre-wrap; word-break: break-word; font-size: 0.84rem; border-radius: 0.5rem; }
+    .detail-card { background:var(--pico-card-background-color); border:1px solid var(--pico-card-border-color); border-radius:0.5rem; padding:0.9rem 1.1rem; margin-bottom:0.75rem; }
+    .detail-card h4 { margin:0 0 0.6rem; font-size:0.82rem; text-transform:uppercase; letter-spacing:0.05em; color:var(--pico-muted-color); }
+    .detail-row { display:flex; gap:1rem; flex-wrap:wrap; }
+    .detail-field { flex:1; min-width:140px; }
+    .detail-field label { font-size:0.78rem; color:var(--pico-muted-color); display:block; margin-bottom:0.15rem; }
+    .detail-field .val { font-size:0.92rem; }
+    .rule-group { margin-bottom:0.4rem; padding:0.4rem 0.7rem; background:rgba(255,255,255,0.04); border-radius:0.35rem; font-size:0.88rem; }
+    pre[class*="language-"] { line-height:1.5 !important; white-space:pre-wrap; word-break:break-word; font-size:0.84rem; border-radius:0.5rem; }
     .line-numbers .line-numbers-rows > span::before { line-height: 1.5; }
     #blockers-panel pre { margin-top: 0.5rem; }
     #autosync-modal { position:fixed; top:50%%; left:50%%; transform:translate(-50%%,-50%%); margin:0; }
     #autosync-modal::backdrop { background:rgba(0,0,0,0.6); }
   </style>
-  <script>
-    document.addEventListener('htmx:afterSwap', function() { Prism.highlightAll(); });
-    document.addEventListener('DOMContentLoaded', function() {
-      var ta = document.getElementById('yaml-viewer');
-      if (ta && typeof CodeMirror !== 'undefined') {
-        CodeMirror.fromTextArea(ta, {
-          mode: 'yaml',
-          theme: 'dracula',
-          lineNumbers: true,
-          lineWrapping: true,
-          readOnly: true,
-          viewportMargin: Infinity,
-          cursorBlinkRate: -1
-        });
-      }
-    });
-  </script>
+  <script>document.addEventListener('htmx:afterSwap', function() { Prism.highlightAll(); });</script>
 </head>
 <body>
 <nav class="topnav">
@@ -889,12 +1094,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 
   <div id="action-result"></div>
 
-  <details open style="margin-top:1rem">
-    <summary style="cursor:pointer;font-weight:600">Config YAML</summary>
-    <div style="margin-top:0.5rem">
-      <textarea id="yaml-viewer" style="display:none">%s</textarea>
-    </div>
-  </details>
+  %s
 
   <div id="blockers-panel" style="margin-top:1.5rem"></div>
 </div>
@@ -909,9 +1109,125 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 		escapedSchema, badge, autoSyncTrigger,
 		autoSyncInfoHTML(cfg),
 		syncActionsHTML, cfg.ID,
-		escapedYAML,
+		configCardsHTML,
 		autoSyncModalHTML(basePath, cfg, canEdit),
 	)
+}
+
+// conditionLabel returns a human-readable label for a condition key.
+func conditionLabel(c string) string {
+	switch c {
+	case "isTheFirstBusinessDayOfTheMonth":
+		return "1st business day of month"
+	case "isTheLastBusinessDayOfTheMonth":
+		return "last business day of month"
+	case "isNonBusinessDay":
+		return "non-business day (weekend / holiday)"
+	default:
+		return c
+	}
+}
+
+// countryLabel returns a human-readable label for a country code.
+func countryLabel(code string) string {
+	switch code {
+	case countryCodeJPN:
+		return "Japan (jpn)"
+	case countryCodeVNM:
+		return "Vietnam (vnm)"
+	default:
+		return code
+	}
+}
+
+// configDetailCardsHTML renders human-readable detail cards from the stored YAML.
+// Falls back to a raw YAML display if parsing fails.
+func configDetailCardsHTML(yamlContent string) string {
+	appCfg, err := appconfig.LoadWithDefaultFromByteArray([]byte(yamlContent))
+	if err != nil {
+		return fmt.Sprintf(`<div class="detail-card"><h4>Config (parse error)</h4><pre style="white-space:pre-wrap;font-size:0.84rem">%s</pre></div>`,
+			html.EscapeString(err.Error()))
+	}
+
+	d := appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default
+
+	// Date range card
+	dateRangeCard := fmt.Sprintf(`
+<div class="detail-card">
+  <h4>Date Range</h4>
+  <div class="detail-row">
+    <div class="detail-field"><label>Lookback</label><div class="val">%d days</div></div>
+    <div class="detail-field"><label>Lookahead</label><div class="val">%d days</div></div>
+  </div>
+</div>`, appCfg.Shared.LookbackDays, appCfg.Shared.LookaheadDays)
+
+	// Holiday source card
+	holidayCard := fmt.Sprintf(`
+<div class="detail-card">
+  <h4>Holiday Source</h4>
+  <div class="detail-field"><label>Country</label><div class="val">%s</div></div>
+</div>`, html.EscapeString(countryLabel(appCfg.ReadFrom.GoogleCalendar.CountryCode)))
+
+	// Freeze rules card
+	var rulesSB strings.Builder
+	for _, rule := range appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf {
+		for anchor, conditions := range rule {
+			var condLabels []string
+			for _, c := range conditions {
+				condLabels = append(condLabels, conditionLabel(c))
+			}
+			fmt.Fprintf(&rulesSB, `<div class="rule-group"><strong>%s</strong> → %s</div>`,
+				html.EscapeString(anchor),
+				html.EscapeString(strings.Join(condLabels, ", ")))
+		}
+	}
+	freezeCard := fmt.Sprintf(`
+<div class="detail-card">
+  <h4>Freeze Rules</h4>
+  <div style="font-size:0.82rem;color:var(--pico-muted-color);margin-bottom:0.5rem">Today is a freeze day if:</div>
+  %s
+</div>`, rulesSB.String())
+
+	// Calendar card
+	calendarCard := fmt.Sprintf(`
+<div class="detail-card">
+  <h4>Target Calendar</h4>
+  <div class="detail-field"><label>Calendar ID</label><div class="val" style="word-break:break-all">%s</div></div>
+</div>`, html.EscapeString(appCfg.WriteTo.GoogleCalendar.ID))
+
+	// Blocker event card
+	summary := ""
+	description := ""
+	startTime := ""
+	endTime := ""
+	if d.Summary != nil {
+		summary = *d.Summary
+	}
+	if d.Description != nil {
+		description = *d.Description
+	}
+	if d.StartTime != nil {
+		startTime = *d.StartTime
+	}
+	if d.EndTime != nil {
+		endTime = *d.EndTime
+	}
+	eventCard := fmt.Sprintf(`
+<div class="detail-card">
+  <h4>Blocker Event</h4>
+  <div class="detail-field" style="margin-bottom:0.5rem"><label>Summary</label><div class="val">%s</div></div>
+  <div class="detail-field" style="margin-bottom:0.5rem"><label>Description</label><div class="val" style="font-size:0.85rem;white-space:pre-wrap">%s</div></div>
+  <div class="detail-row">
+    <div class="detail-field"><label>Start</label><div class="val">%s</div></div>
+    <div class="detail-field"><label>End</label><div class="val">%s</div></div>
+  </div>
+</div>`,
+		html.EscapeString(summary),
+		html.EscapeString(description),
+		html.EscapeString(startTime),
+		html.EscapeString(endTime))
+
+	return dateRangeCard + holidayCard + freezeCard + calendarCard + eventCard
 }
 
 func syncScheduleOptions(selected string) string {
@@ -934,7 +1250,7 @@ func syncScheduleOptions(selected string) string {
 	return sb.String()
 }
 
-func configFormHTML(title, action, backURL, schemaVersion, name, yamlContent, _ /* schemaYAML */, formErr string, isEdit bool, syncSchedule string, cals []*googlecalendar.CalendarItem, basePath string) string {
+func configFormHTML(title, action, backURL string, data configFormData, formErr string, isEdit bool, cals []*googlecalendar.CalendarItem, basePath string) string {
 	errHTML := ""
 	if formErr != "" {
 		errHTML = fmt.Sprintf(`<div style="background:#4a1122;border:1px solid #7f1d1d;color:#f87171;padding:0.75rem 1rem;border-radius:0.5rem;margin-bottom:1rem">%s</div>`,
@@ -944,34 +1260,11 @@ func configFormHTML(title, action, backURL, schemaVersion, name, yamlContent, _ 
 	var breadcrumb, pageHeader string
 	if isEdit {
 		breadcrumb = fmt.Sprintf(`<a href="`+basePath+`/dashboard">Configs</a> &rsaquo; <a href="%s">%s</a> &rsaquo; Edit`,
-			html.EscapeString(backURL), html.EscapeString(name))
-		pageHeader = fmt.Sprintf(`Edit: %s`, html.EscapeString(name))
+			html.EscapeString(backURL), html.EscapeString(data.Name))
+		pageHeader = fmt.Sprintf(`Edit: %s`, html.EscapeString(data.Name))
 	} else {
 		breadcrumb = `<a href="` + basePath + `/dashboard">Configs</a> &rsaquo; New Config`
 		pageHeader = `New Config`
-	}
-
-	defaultYAML := `shared:
-  lookbackDays: 20
-  lookaheadDays: 20
-
-readFrom:
-  googleCalendar:
-    countryCode: "jpn"
-    todayIsFreezeDayIf:
-    - today:
-      - isTheFirstBusinessDayOfTheMonth
-    - today:
-      - isTheLastBusinessDayOfTheMonth
-    - tomorrow:
-      - isNonBusinessDay
-
-writeTo:
-  googleCalendar:
-    id: "ngo.van.anh.tuan@moneyforward.co.jp"`
-
-	if yamlContent == "" {
-		yamlContent = defaultYAML
 	}
 
 	deleteBtn := ""
@@ -980,26 +1273,15 @@ writeTo:
 			html.EscapeString(action))
 	}
 
-	calPicker := calendarOptions(cals)
+	calPicker := calendarPickerHTML(cals, data.CalendarID)
 
 	schemaPicker := fmt.Sprintf(`
-<label for="schema_version">Schema Version
-  <div style="display:flex;align-items:center;gap:0.5rem">
-    <select id="schema_version" name="schema_version" style="flex:1;margin:0">
-      <option value="v1"%s>v1 (current)</option>
-    </select>
-    <a href="`+basePath+`/schema/%s" target="_blank" title="View schema reference for %s"
-       style="font-size:1.1rem;text-decoration:none;flex-shrink:0">ℹ️</a>
-  </div>
-</label>`,
-		func() string {
-			if schemaVersion == "v1" {
-				return " selected"
-			}
-			return ""
-		}(),
-		html.EscapeString(schemaVersion),
-		html.EscapeString(schemaVersion),
+<div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:1rem">
+  <span style="font-size:0.88rem;color:var(--pico-muted-color)">Schema: <strong>%s</strong></span>
+  <a href="`+basePath+`/schema/%s" target="_blank" title="View schema reference" style="font-size:1rem;text-decoration:none">ℹ️</a>
+</div>`,
+		html.EscapeString(data.SchemaVersion),
+		html.EscapeString(data.SchemaVersion),
 	)
 
 	autoSyncPicker := fmt.Sprintf(`
@@ -1008,7 +1290,25 @@ writeTo:
     %s
   </select>
   <small style="color:var(--pico-muted-color)">Weekly fires every Monday 09:00 JST. Monthly fires on the 1st at 09:00 JST. When enabled, manual Sync and Wipe are disabled.</small>
-</label>`, syncScheduleOptions(syncSchedule))
+</label>`, syncScheduleOptions(data.SyncSchedule))
+
+	// Country select
+	countryOptions := ""
+	for _, cc := range []struct{ val, label string }{
+		{countryCodeJPN, "Japan (jpn)"},
+		{countryCodeVNM, "Vietnam (vnm)"},
+	} {
+		sel := ""
+		if cc.val == data.CountryCode {
+			sel = " selected"
+		}
+		countryOptions += fmt.Sprintf(`<option value="%s"%s>%s</option>`, cc.val, sel, cc.label)
+	}
+
+	initialRulesJSON := rulesToJSON(data.Rules)
+	if initialRulesJSON == "null" || initialRulesJSON == "" {
+		initialRulesJSON = "[]"
+	}
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -1018,32 +1318,26 @@ writeTo:
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>%s &#8211; TGI Freeze Day</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/theme/dracula.min.css">
   <style>
-    nav.topnav { background: var(--pico-card-background-color); border-bottom: 1px solid var(--pico-card-border-color); padding: 0.75rem 1.5rem; display:flex; align-items:center; justify-content:space-between; }
+    nav.topnav { background:var(--pico-card-background-color); border-bottom:1px solid var(--pico-card-border-color); padding:0.75rem 1.5rem; display:flex; align-items:center; justify-content:space-between; }
     nav.topnav .brand { font-weight:700; text-decoration:none; color:inherit; }
-    .page-content { max-width: 760px; margin: 2rem auto; padding: 0 1.5rem; }
+    .page-content { max-width:760px; margin:2rem auto; padding:0 1.5rem; }
     .breadcrumb { font-size:0.82rem; color:var(--pico-muted-color); margin-bottom:0.4rem; }
     .breadcrumb a { color:var(--pico-muted-color); text-decoration:none; }
     .breadcrumb a:hover { text-decoration:underline; }
     .back-btn { font-size:1.4rem; text-decoration:none; color:var(--pico-muted-color); line-height:1; flex-shrink:0; }
     .back-btn:hover { color:var(--pico-color); }
     .form-actions { display:flex; gap:0.6rem; align-items:center; flex-wrap:wrap; }
-    .form-actions button, .form-actions a[role=button] { margin:0; width:auto; padding:0.45rem 1.1rem; font-size:0.9rem; }
-    .CodeMirror {
-      height: 480px;
-      font-size: 0.88rem;
-      font-family: monospace;
-      border: 1px solid var(--pico-form-element-border-color);
-      border-radius: var(--pico-border-radius);
-      line-height: 1.5;
-    }
-    .CodeMirror-scroll { padding-bottom: 0.5rem; }
-    label.yaml-label { display:block; margin-bottom:0.25rem; font-weight:500; }
+    .form-actions button,.form-actions a[role=button] { margin:0; width:auto; padding:0.45rem 1.1rem; font-size:0.9rem; }
+    .section-header { font-size:0.78rem; font-weight:600; text-transform:uppercase; letter-spacing:0.05em; color:var(--pico-muted-color); border-bottom:1px solid var(--pico-card-border-color); padding-bottom:0.3rem; margin:1.25rem 0 0.75rem; }
+    .two-col { display:grid; grid-template-columns:1fr 1fr; gap:0.75rem; }
+    .rule-group-box { background:var(--pico-card-background-color); border:1px solid var(--pico-card-border-color); border-radius:0.4rem; padding:0.65rem 0.75rem; margin-bottom:0.5rem; }
+    .rule-cond-row { display:flex; align-items:center; gap:0.5rem; margin-bottom:0.35rem; }
+    .rule-cond-row select { flex:1; margin:0; padding:0.3rem 0.5rem; font-size:0.85rem; }
+    .rule-cond-row button { margin:0; padding:0.25rem 0.55rem; font-size:0.8rem; }
+    .btn-small { padding:0.3rem 0.65rem !important; font-size:0.82rem !important; }
+    .or-divider { text-align:center; font-size:0.8rem; color:var(--pico-muted-color); margin:0.25rem 0; }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/yaml/yaml.min.js"></script>
 </head>
 <body>
 <nav class="topnav">
@@ -1062,13 +1356,60 @@ writeTo:
       <input type="text" id="name" name="name" value="%s" placeholder="e.g. Japan prod freeze" required>
     </label>
     %s
-    %s
-    %s
-    <div style="margin-bottom:1rem">
-      <label class="yaml-label" for="config_yaml">Config YAML</label>
-      <textarea id="config_yaml" name="config_yaml" style="display:none">%s</textarea>
+
+    <div class="section-header">Date Range</div>
+    <div class="two-col">
+      <label for="lookback_days">Lookback days
+        <input type="number" id="lookback_days" name="lookback_days" value="%d" min="20" max="60" required>
+        <small style="color:var(--pico-muted-color)">20–60</small>
+      </label>
+      <label for="lookahead_days">Lookahead days
+        <input type="number" id="lookahead_days" name="lookahead_days" value="%d" min="20" max="60" required>
+        <small style="color:var(--pico-muted-color)">20–60</small>
+      </label>
     </div>
-    <div class="form-actions">
+
+    <div class="section-header">Holiday Source</div>
+    <label for="country_code">Country
+      <select id="country_code" name="country_code">%s</select>
+    </label>
+
+    <div class="section-header">Freeze Rules</div>
+    <p style="font-size:0.85rem;color:var(--pico-muted-color);margin-bottom:0.75rem">
+      Today is a freeze day if <em>any</em> rule group matches (OR). Within a group, <em>all</em> conditions must match (AND).
+    </p>
+    <div id="rules-container"></div>
+    <button type="button" class="outline btn-small" onclick="addRuleGroup()" style="margin-bottom:1rem">+ OR group</button>
+    <input type="hidden" id="rules_json" name="rules_json">
+
+    <div class="section-header">Target Calendar</div>
+    %s
+    <label for="write_calendar_id">Calendar ID
+      <input type="text" id="write_calendar_id" name="write_calendar_id" value="%s" placeholder="team-cal@group.calendar.google.com" required>
+    </label>
+
+    <div class="section-header">Blocker Event</div>
+    <label for="event_summary">Summary
+      <input type="text" id="event_summary" name="event_summary" value="%s" maxlength="250" placeholder="🚫 PRODUCTION FREEZE - No Deployments" required>
+      <small style="color:var(--pico-muted-color)">Max 250 characters</small>
+    </label>
+    <label for="event_description">Description
+      <textarea id="event_description" name="event_description" rows="4" maxlength="8000" placeholder="Production operations restricted today.">%s</textarea>
+      <small style="color:var(--pico-muted-color)">HTML supported: &lt;br&gt;, &lt;ul&gt;&lt;li&gt;, &lt;a href=""&gt;, &lt;strong&gt;, &lt;em&gt;. Max 8000 characters.</small>
+    </label>
+    <div class="two-col">
+      <label for="start_time">Start time
+        <input type="time" id="start_time" name="start_time" value="%s" required>
+      </label>
+      <label for="end_time">End time
+        <input type="time" id="end_time" name="end_time" value="%s" required>
+      </label>
+    </div>
+
+    <div class="section-header">Auto-Sync</div>
+    %s
+
+    <div class="form-actions" style="margin-top:1.5rem">
       <button type="submit">Save</button>
       %s
       <a href="%s" role="button" class="outline secondary">Cancel</a>
@@ -1076,19 +1417,95 @@ writeTo:
   </form>
 </div>
 <script>
-window.cmEditor = CodeMirror.fromTextArea(document.getElementById('config_yaml'), {
-  mode: 'yaml',
-  theme: 'dracula',
-  lineNumbers: true,
-  lineWrapping: true,
-  tabSize: 2,
-  indentWithTabs: false,
-  autofocus: false,
-  extraKeys: { Tab: function(cm) { cm.replaceSelection('  '); } }
-});
+var ANCHORS = [
+  {value:'today', label:'today'},
+  {value:'tomorrow', label:'tomorrow'},
+  {value:'nextDay', label:'next day'}
+];
+var CONDITIONS = [
+  {value:'isTheFirstBusinessDayOfTheMonth', label:'1st business day of month'},
+  {value:'isTheLastBusinessDayOfTheMonth', label:'last business day of month'},
+  {value:'isNonBusinessDay', label:'non-business day (weekend / holiday)'}
+];
+
+var rules = %s;
+if (!Array.isArray(rules) || rules.length === 0) {
+  rules = [{anchor:'today', conditions:['isTheFirstBusinessDayOfTheMonth']}];
+}
+
+function anchorSelect(groupIdx, val) {
+  var s = '<select onchange="rules['+groupIdx+'].anchor=this.value">';
+  ANCHORS.forEach(function(a) {
+    s += '<option value="'+a.value+'"'+(a.value===val?' selected':'')+'>'+a.label+'</option>';
+  });
+  return s+'</select>';
+}
+
+function condSelect(groupIdx, condIdx, val) {
+  var s = '<select onchange="rules['+groupIdx+'].conditions['+condIdx+']=this.value">';
+  CONDITIONS.forEach(function(c) {
+    s += '<option value="'+c.value+'"'+(c.value===val?' selected':'')+'>'+c.label+'</option>';
+  });
+  return s+'</select>';
+}
+
+function renderRules() {
+  var container = document.getElementById('rules-container');
+  var html = '';
+  rules.forEach(function(group, gi) {
+    html += '<div class="rule-group-box">';
+    html += '<div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem">';
+    html += anchorSelect(gi, group.anchor);
+    html += '<span style="font-size:0.85rem;color:var(--pico-muted-color)">is:</span>';
+    if (rules.length > 1) {
+      html += '<button type="button" class="outline contrast btn-small" style="margin-left:auto" onclick="removeGroup('+gi+')" title="Remove this OR group">✕ group</button>';
+    }
+    html += '</div>';
+    group.conditions.forEach(function(cond, ci) {
+      html += '<div class="rule-cond-row">';
+      html += '<span style="font-size:0.8rem;color:var(--pico-muted-color);flex-shrink:0">—</span>';
+      html += condSelect(gi, ci, cond);
+      if (group.conditions.length > 1) {
+        html += '<button type="button" class="outline btn-small" onclick="removeCond('+gi+','+ci+')" title="Remove condition">✕</button>';
+      }
+      html += '</div>';
+    });
+    html += '<button type="button" class="outline btn-small" onclick="addCond('+gi+')" style="margin-top:0.25rem">+ AND condition</button>';
+    html += '</div>';
+    if (gi < rules.length - 1) {
+      html += '<div class="or-divider">— or —</div>';
+    }
+  });
+  container.innerHTML = html;
+}
+
+function addRuleGroup() {
+  rules.push({anchor:'today', conditions:['isTheFirstBusinessDayOfTheMonth']});
+  renderRules();
+}
+
+function removeGroup(gi) {
+  if (rules.length <= 1) return;
+  rules.splice(gi, 1);
+  renderRules();
+}
+
+function addCond(gi) {
+  rules[gi].conditions.push('isTheFirstBusinessDayOfTheMonth');
+  renderRules();
+}
+
+function removeCond(gi, ci) {
+  if (rules[gi].conditions.length <= 1) return;
+  rules[gi].conditions.splice(ci, 1);
+  renderRules();
+}
+
 document.getElementById('config-form').addEventListener('submit', function() {
-  window.cmEditor.save();
+  document.getElementById('rules_json').value = JSON.stringify(rules);
 });
+
+renderRules();
 </script>
 `+pageFooterHTML()+`
 </body>
@@ -1100,12 +1517,20 @@ document.getElementById('config-form').addEventListener('submit', function() {
 		pageHeader,
 		errHTML,
 		html.EscapeString(action),
-		html.EscapeString(name),
+		html.EscapeString(data.Name),
 		schemaPicker,
-		autoSyncPicker,
+		data.LookbackDays,
+		data.LookaheadDays,
+		countryOptions,
 		calPicker,
-		html.EscapeString(yamlContent),
+		html.EscapeString(data.CalendarID),
+		html.EscapeString(data.Summary),
+		html.EscapeString(data.Description),
+		data.StartTime,
+		data.EndTime,
+		autoSyncPicker,
 		deleteBtn,
 		html.EscapeString(backURL),
+		initialRulesJSON,
 	)
 }

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -1157,6 +1157,16 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 	)
 }
 
+// sectionHeaderHTML renders a section divider with an optional (?) tooltip.
+func sectionHeaderHTML(label, tooltip string) string {
+	tipHTML := ""
+	if tooltip != "" {
+		tipHTML = fmt.Sprintf(` <span title="%s" style="cursor:help;font-weight:normal;font-size:0.82rem;opacity:0.6;margin-left:0.3rem">(?)</span>`,
+			html.EscapeString(tooltip))
+	}
+	return fmt.Sprintf(`<div class="section-header">%s%s</div>`, html.EscapeString(label), tipHTML)
+}
+
 // conditionLabel returns a human-readable label for a condition key.
 func conditionLabel(c string) string {
 	switch c {
@@ -1197,7 +1207,7 @@ func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string
 	// Date range card
 	dateRangeCard := fmt.Sprintf(`
 <div class="detail-card">
-  <h4>Date Range</h4>
+  <h4>Date Range <span title="How far back and forward to scan for freeze days." style="cursor:help;font-weight:normal;font-size:0.8rem;opacity:0.5">(?)</span></h4>
   <div class="detail-row">
     <div class="detail-field"><label>Lookback</label><div class="val">%d days</div></div>
     <div class="detail-field"><label>Lookahead</label><div class="val">%d days</div></div>
@@ -1207,26 +1217,29 @@ func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string
 	// Holiday source card
 	holidayCard := fmt.Sprintf(`
 <div class="detail-card">
-  <h4>Holiday Source</h4>
+  <h4>Holiday Source <span title="The public holiday calendar to read from, used to identify non-business days." style="cursor:help;font-weight:normal;font-size:0.8rem;opacity:0.5">(?)</span></h4>
   <div class="detail-field"><label>Country</label><div class="val">%s</div></div>
 </div>`, html.EscapeString(countryLabel(appCfg.ReadFrom.GoogleCalendar.CountryCode)))
 
 	// Freeze rules card
 	var rulesSB strings.Builder
-	for _, rule := range appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf {
+	for i, rule := range appCfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf {
+		if i > 0 {
+			rulesSB.WriteString(`<div style="font-size:0.78rem;font-weight:700;color:#60a5fa;text-align:center;margin:0.3rem 0;letter-spacing:0.05em">OR</div>`)
+		}
 		for anchor, conditions := range rule {
-			var condLabels []string
+			var condParts []string
 			for _, c := range conditions {
-				condLabels = append(condLabels, conditionLabel(c))
+				condParts = append(condParts, html.EscapeString(conditionLabel(c)))
 			}
-			fmt.Fprintf(&rulesSB, `<div class="rule-group"><strong>%s</strong> → %s</div>`,
-				html.EscapeString(anchor),
-				html.EscapeString(strings.Join(condLabels, ", ")))
+			condHTML := strings.Join(condParts, ` <span style="font-size:0.75rem;font-weight:700;color:#a78bfa;margin:0 0.2rem">AND</span> `)
+			fmt.Fprintf(&rulesSB, `<div class="rule-group"><strong>%s</strong> <span style="color:var(--pico-muted-color);font-size:0.82rem">is:</span> %s</div>`,
+				html.EscapeString(anchor), condHTML)
 		}
 	}
 	freezeCard := fmt.Sprintf(`
 <div class="detail-card">
-  <h4>Freeze Rules</h4>
+  <h4>Freeze Rules <span title="Today is a freeze day if any group matches (OR). Within a group, all conditions must match (AND)." style="cursor:help;font-weight:normal;font-size:0.8rem;opacity:0.5">(?)</span></h4>
   <div style="font-size:0.82rem;color:var(--pico-muted-color);margin-bottom:0.5rem">Today is a freeze day if:</div>
   %s
 </div>`, rulesSB.String())
@@ -1243,7 +1256,7 @@ func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string
 	}
 	calendarCard := fmt.Sprintf(`
 <div class="detail-card">
-  <h4>Target Calendar</h4>
+  <h4>Target Calendar <span title="The Google Calendar where blocker events are written on freeze days." style="cursor:help;font-weight:normal;font-size:0.8rem;opacity:0.5">(?)</span></h4>
   <div class="detail-field"><div class="val">%s</div></div>
 </div>`, calDisplay)
 
@@ -1277,7 +1290,7 @@ func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string
 	}
 	eventCard := fmt.Sprintf(`
 <div class="detail-card">
-  <h4>Blocker Event</h4>
+  <h4>Blocker Event <span title="The calendar event created on each freeze day to signal no deployments allowed." style="cursor:help;font-weight:normal;font-size:0.8rem;opacity:0.5">(?)</span></h4>
   <div class="detail-field" style="margin-bottom:0.5rem"><label>Summary</label><div class="val">%s</div></div>
   <div class="detail-field" style="margin-bottom:0.5rem"><label>Description</label><div class="val" style="font-size:0.85rem;white-space:pre-wrap">%s</div></div>
   %s
@@ -1417,7 +1430,7 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
       <input type="text" id="name" name="name" value="%s" placeholder="e.g. Japan prod freeze" required>
     </label>
 
-    <div class="section-header">Date Range</div>
+    `+sectionHeaderHTML("Date Range", "How far back and forward to scan for freeze days. Lookback covers past days already elapsed; lookahead covers upcoming days.")+`
     <div class="two-col">
       <label for="lookback_days">Lookback days
         <input type="number" id="lookback_days" name="lookback_days" value="%d" min="20" max="60" required>
@@ -1429,12 +1442,12 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
       </label>
     </div>
 
-    <div class="section-header">Holiday Source</div>
+    `+sectionHeaderHTML("Holiday Source", "The public holiday calendar to read from. Used to identify non-business days (weekends + public holidays) in the target country.")+`
     <label for="country_code">Country
       <select id="country_code" name="country_code">%s</select>
     </label>
 
-    <div class="section-header">Freeze Rules</div>
+    `+sectionHeaderHTML("Freeze Rules", "Defines when today counts as a freeze day. Groups are OR'd — if any group matches, today is a freeze day. Within a group, all conditions must match (AND).")+`
     <p style="font-size:0.85rem;color:var(--pico-muted-color);margin-bottom:0.75rem">
       Today is a freeze day if <em>any</em> rule group matches (OR). Within a group, <em>all</em> conditions must match (AND).
     </p>
@@ -1442,13 +1455,13 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
     <button type="button" class="outline btn-small" onclick="addRuleGroup()" style="margin-bottom:1rem">+ OR group</button>
     <input type="hidden" id="rules_json" name="rules_json">
 
-    <div class="section-header">Target Calendar</div>
+    `+sectionHeaderHTML("Target Calendar", "The Google Calendar where blocker events will be written on freeze days. Must be a calendar you have write access to.")+`
     %s
     <label for="write_calendar_id">Calendar ID
       <input type="text" id="write_calendar_id" name="write_calendar_id" value="%s" placeholder="team-cal@group.calendar.google.com" required>
     </label>
 
-    <div class="section-header">Blocker Event</div>
+    `+sectionHeaderHTML("Blocker Event", "The calendar event created on each freeze day. Title and description appear in Google Calendar to signal no deployments allowed.")+`
     <label for="event_summary">Summary
       <input type="text" id="event_summary" name="event_summary" value="%s" maxlength="250" placeholder="🚫 PRODUCTION FREEZE - No Deployments" required>
       <small style="color:var(--pico-muted-color)">Max 250 characters</small>
@@ -1475,7 +1488,7 @@ func configFormHTML(title, action, backURL string, data configFormData, formErr 
       </div>
     </div>
 
-    <div class="section-header">Auto-Sync</div>
+    `+sectionHeaderHTML("Auto-Sync", "Runs Sync automatically on a schedule so you don't have to click manually. When enabled, manual Sync and Wipe are disabled to prevent conflicts.")+`
     %s
 
     <div class="form-actions" style="margin-top:1.5rem">
@@ -1532,17 +1545,21 @@ function renderRules() {
     html += '</div>';
     group.conditions.forEach(function(cond, ci) {
       html += '<div class="rule-cond-row">';
-      html += '<span style="font-size:0.8rem;color:var(--pico-muted-color);flex-shrink:0">—</span>';
+      if (ci === 0) {
+        html += '<span style="font-size:0.8rem;color:var(--pico-muted-color);flex-shrink:0;min-width:2.5rem">is:</span>';
+      } else {
+        html += '<span style="font-size:0.75rem;font-weight:700;color:#a78bfa;flex-shrink:0;min-width:2.5rem">AND</span>';
+      }
       html += condSelect(gi, ci, cond);
       if (group.conditions.length > 1) {
         html += '<button type="button" class="outline btn-small" onclick="removeCond('+gi+','+ci+')" title="Remove condition">✕</button>';
       }
       html += '</div>';
     });
-    html += '<button type="button" class="outline btn-small" onclick="addCond('+gi+')" style="margin-top:0.25rem">+ AND condition</button>';
+    html += '<button type="button" class="outline btn-small" onclick="addCond('+gi+')" style="margin-top:0.25rem;margin-left:2.9rem">+ AND condition</button>';
     html += '</div>';
     if (gi < rules.length - 1) {
-      html += '<div class="or-divider">— or —</div>';
+      html += '<div class="or-divider" style="font-weight:700;color:#60a5fa;letter-spacing:0.08em">— OR —</div>';
     }
   });
   container.innerHTML = html;

--- a/internal/web/handler/config.go
+++ b/internal/web/handler/config.go
@@ -156,16 +156,18 @@ func (h *ConfigHandler) HandleDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	role := roleFromContext(r.Context())
 
-	// Parse once; resolve calendar name from the result.
+	// Parse once; validate; resolve calendar name from the result.
 	var parsedCfg *appconfig.Config
 	calendarName := ""
 	if appCfg, parseErr := appconfig.LoadWithDefaultFromByteArray([]byte(cfg.ConfigYAML)); parseErr == nil {
-		parsedCfg = appCfg
-		calID := appCfg.WriteTo.GoogleCalendar.ID
-		for _, cal := range h.fetchCalendars(r.Context(), user.ID) {
-			if cal.ID == calID {
-				calendarName = cal.Summary
-				break
+		if appCfg.Validate() == nil {
+			parsedCfg = appCfg
+			calID := appCfg.WriteTo.GoogleCalendar.ID
+			for _, cal := range h.fetchCalendars(r.Context(), user.ID) {
+				if cal.ID == calID {
+					calendarName = cal.Summary
+					break
+				}
 			}
 		}
 	}
@@ -1058,7 +1060,7 @@ func configDetailHTML(basePath string, cfg *db.Config, currentUserID int64, role
 	autoSyncTrigger := autoSyncTriggerHTML(cfg, canEdit)
 
 	// Build human-readable config detail cards.
-	configCardsHTML := configDetailCardsHTML(appCfg, calendarName)
+	configCardsHTML := configDetailCardsHTML(appCfg, calendarName, cfg.ConfigYAML)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -1197,9 +1199,15 @@ func countryLabel(code string) string {
 // configDetailCardsHTML renders human-readable detail cards from the parsed config.
 // Falls back to a generic parse-error notice when appCfg is nil.
 // calendarName is the human-readable name for the write calendar (empty string = show ID only).
-func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string) string {
+func configDetailCardsHTML(appCfg *appconfig.Config, calendarName string, rawYAML string) string {
 	if appCfg == nil {
-		return `<div class="detail-card"><h4>Config (parse error)</h4><p style="font-size:0.84rem;color:var(--pico-muted-color)">Could not parse config YAML.</p></div>`
+		escaped := html.EscapeString(rawYAML)
+		if escaped == "" {
+			escaped = "(empty)"
+		}
+		return fmt.Sprintf(`<div class="detail-card"><h4>Config (parse / validation error)</h4>
+<p style="font-size:0.84rem;color:var(--pico-muted-color);margin-bottom:0.5rem">Could not parse or validate this config. Raw YAML below:</p>
+<pre style="font-size:0.8rem;white-space:pre-wrap;word-break:break-word;overflow:auto;max-height:400px;background:rgba(0,0,0,0.25);padding:0.75rem;border-radius:0.4rem">%s</pre></div>`, escaped)
 	}
 
 	d := appCfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default

--- a/internal/web/handler/config_form_test.go
+++ b/internal/web/handler/config_form_test.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	appconfig "github.com/nvat/tgifreezeday/internal/config"
+)
+
+// makeFormRequest builds a POST *http.Request with the given form values.
+func makeFormRequest(values url.Values) *http.Request {
+	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(values.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	_ = r.ParseForm()
+	return r
+}
+
+func rulesJSON(t *testing.T, rules []formRule) string {
+	t.Helper()
+	b, err := json.Marshal(rules)
+	if err != nil {
+		t.Fatalf("json.Marshal rules: %v", err)
+	}
+	return string(b)
+}
+
+func TestFormToAppConfig_ValidInput(t *testing.T) {
+	rules := []formRule{
+		{Anchor: "today", Conditions: []string{"isTheFirstBusinessDayOfTheMonth", "isTheLastBusinessDayOfTheMonth"}},
+		{Anchor: "tomorrow", Conditions: []string{"isNonBusinessDay"}},
+	}
+	form := url.Values{
+		"lookback_days":     {"20"},
+		"lookahead_days":    {"60"},
+		"country_code":      {countryCodeJPN},
+		"write_calendar_id": {"team-cal@group.calendar.google.com"},
+		"event_summary":     {"🚫 PRODUCTION FREEZE"},
+		"event_description": {"No prod ops today."},
+		"start_time":        {"08:00"},
+		"end_time":          {"20:00"},
+		"rules_json":        {rulesJSON(t, rules)},
+	}
+	r := makeFormRequest(form)
+
+	cfg, err := formToAppConfig(r)
+	if err != nil {
+		t.Fatalf("formToAppConfig() error = %v", err)
+	}
+
+	if cfg.Shared.LookbackDays != 20 {
+		t.Errorf("LookbackDays = %d, want 20", cfg.Shared.LookbackDays)
+	}
+	if cfg.Shared.LookaheadDays != 60 {
+		t.Errorf("LookaheadDays = %d, want 60", cfg.Shared.LookaheadDays)
+	}
+	if cfg.ReadFrom.GoogleCalendar.CountryCode != "jpn" {
+		t.Errorf("CountryCode = %q, want jpn", cfg.ReadFrom.GoogleCalendar.CountryCode)
+	}
+	if cfg.WriteTo.GoogleCalendar.ID != "team-cal@group.calendar.google.com" {
+		t.Errorf("CalendarID = %q", cfg.WriteTo.GoogleCalendar.ID)
+	}
+	if got := cfg.ReadFrom.GoogleCalendar.TodayIsFreezeDayIf; len(got) != 2 {
+		t.Errorf("len(Rules) = %d, want 2", len(got))
+	}
+	if cfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary == nil ||
+		*cfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default.Summary != "🚫 PRODUCTION FREEZE" {
+		t.Errorf("Summary mismatch")
+	}
+}
+
+func TestFormToAppConfig_RoundTrip(t *testing.T) {
+	rules := []formRule{
+		{Anchor: "today", Conditions: []string{"isTheLastBusinessDayOfTheMonth"}},
+	}
+	form := url.Values{
+		"lookback_days":     {"30"},
+		"lookahead_days":    {"45"},
+		"country_code":      {"vnm"},
+		"write_calendar_id": {"myteam@group.calendar.google.com"},
+		"event_summary":     {"Freeze"},
+		"event_description": {"No deployments."},
+		"start_time":        {"09:00"},
+		"end_time":          {"18:00"},
+		"rules_json":        {rulesJSON(t, rules)},
+	}
+	r := makeFormRequest(form)
+
+	cfg, err := formToAppConfig(r)
+	if err != nil {
+		t.Fatalf("formToAppConfig() error = %v", err)
+	}
+
+	yamlStr, err := cfg.ToYAML()
+	if err != nil {
+		t.Fatalf("ToYAML() error = %v", err)
+	}
+	if yamlStr == "" {
+		t.Fatal("ToYAML() returned empty string")
+	}
+
+	// Re-parse and validate
+	parsed, err := appconfig.LoadWithDefaultFromByteArray([]byte(yamlStr))
+	if err != nil {
+		t.Fatalf("LoadWithDefaultFromByteArray() error = %v", err)
+	}
+	if err := parsed.Validate(); err != nil {
+		t.Fatalf("Validate() after round-trip error = %v", err)
+	}
+	if parsed.Shared.LookbackDays != 30 {
+		t.Errorf("LookbackDays after round-trip = %d, want 30", parsed.Shared.LookbackDays)
+	}
+}
+
+func TestFormToAppConfig_MissingRules(t *testing.T) {
+	form := url.Values{
+		"lookback_days":     {"20"},
+		"lookahead_days":    {"60"},
+		"country_code":      {"jpn"},
+		"write_calendar_id": {"cal@group.calendar.google.com"},
+		"event_summary":     {"Freeze"},
+		"event_description": {"No ops"},
+		"start_time":        {"08:00"},
+		"end_time":          {"20:00"},
+		"rules_json":        {""},
+	}
+	r := makeFormRequest(form)
+	_, err := formToAppConfig(r)
+	if err == nil {
+		t.Error("formToAppConfig() expected error for empty rules_json, got nil")
+	}
+}
+
+func TestFormToAppConfig_InvalidLookback(t *testing.T) {
+	form := url.Values{
+		"lookback_days":  {"notanumber"},
+		"lookahead_days": {"60"},
+		"rules_json":     {`[{"anchor":"today","conditions":["isNonBusinessDay"]}]`},
+	}
+	r := makeFormRequest(form)
+	_, err := formToAppConfig(r)
+	if err == nil {
+		t.Error("formToAppConfig() expected error for invalid lookback_days, got nil")
+	}
+}

--- a/internal/web/handler/config_form_test.go
+++ b/internal/web/handler/config_form_test.go
@@ -10,6 +10,12 @@ import (
 	appconfig "github.com/nvat/tgifreezeday/internal/config"
 )
 
+const (
+	formKeyLookback  = "lookback_days"
+	formKeyLookahead = "lookahead_days"
+	formKeyRulesJSON = "rules_json"
+)
+
 // makeFormRequest builds a POST *http.Request with the given form values.
 func makeFormRequest(values url.Values) *http.Request {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(values.Encode()))
@@ -29,19 +35,19 @@ func rulesJSON(t *testing.T, rules []formRule) string {
 
 func TestFormToAppConfig_ValidInput(t *testing.T) {
 	rules := []formRule{
-		{Anchor: "today", Conditions: []string{"isTheFirstBusinessDayOfTheMonth", "isTheLastBusinessDayOfTheMonth"}},
-		{Anchor: "tomorrow", Conditions: []string{"isNonBusinessDay"}},
+		{Anchor: ruleAnchorToday, Conditions: []string{"isTheFirstBusinessDayOfTheMonth", "isTheLastBusinessDayOfTheMonth"}},
+		{Anchor: ruleAnchorTomorrow, Conditions: []string{"isNonBusinessDay"}},
 	}
 	form := url.Values{
-		"lookback_days":     {"20"},
-		"lookahead_days":    {"60"},
+		formKeyLookback:     {"20"},
+		formKeyLookahead:    {"60"},
 		"country_code":      {countryCodeJPN},
 		"write_calendar_id": {"team-cal@group.calendar.google.com"},
 		"event_summary":     {"🚫 PRODUCTION FREEZE"},
 		"event_description": {"No prod ops today."},
 		"start_time":        {"08:00"},
 		"end_time":          {"20:00"},
-		"rules_json":        {rulesJSON(t, rules)},
+		formKeyRulesJSON:    {rulesJSON(t, rules)},
 	}
 	r := makeFormRequest(form)
 
@@ -56,8 +62,8 @@ func TestFormToAppConfig_ValidInput(t *testing.T) {
 	if cfg.Shared.LookaheadDays != 60 {
 		t.Errorf("LookaheadDays = %d, want 60", cfg.Shared.LookaheadDays)
 	}
-	if cfg.ReadFrom.GoogleCalendar.CountryCode != "jpn" {
-		t.Errorf("CountryCode = %q, want jpn", cfg.ReadFrom.GoogleCalendar.CountryCode)
+	if cfg.ReadFrom.GoogleCalendar.CountryCode != countryCodeJPN {
+		t.Errorf("CountryCode = %q, want %s", cfg.ReadFrom.GoogleCalendar.CountryCode, countryCodeJPN)
 	}
 	if cfg.WriteTo.GoogleCalendar.ID != "team-cal@group.calendar.google.com" {
 		t.Errorf("CalendarID = %q", cfg.WriteTo.GoogleCalendar.ID)
@@ -73,18 +79,18 @@ func TestFormToAppConfig_ValidInput(t *testing.T) {
 
 func TestFormToAppConfig_RoundTrip(t *testing.T) {
 	rules := []formRule{
-		{Anchor: "today", Conditions: []string{"isTheLastBusinessDayOfTheMonth"}},
+		{Anchor: ruleAnchorToday, Conditions: []string{"isTheLastBusinessDayOfTheMonth"}},
 	}
 	form := url.Values{
-		"lookback_days":     {"30"},
-		"lookahead_days":    {"45"},
+		formKeyLookback:     {"30"},
+		formKeyLookahead:    {"45"},
 		"country_code":      {"vnm"},
 		"write_calendar_id": {"myteam@group.calendar.google.com"},
 		"event_summary":     {"Freeze"},
 		"event_description": {"No deployments."},
 		"start_time":        {"09:00"},
 		"end_time":          {"18:00"},
-		"rules_json":        {rulesJSON(t, rules)},
+		formKeyRulesJSON:    {rulesJSON(t, rules)},
 	}
 	r := makeFormRequest(form)
 
@@ -116,15 +122,15 @@ func TestFormToAppConfig_RoundTrip(t *testing.T) {
 
 func TestFormToAppConfig_MissingRules(t *testing.T) {
 	form := url.Values{
-		"lookback_days":     {"20"},
-		"lookahead_days":    {"60"},
-		"country_code":      {"jpn"},
+		formKeyLookback:     {"20"},
+		formKeyLookahead:    {"60"},
+		"country_code":      {countryCodeJPN},
 		"write_calendar_id": {"cal@group.calendar.google.com"},
 		"event_summary":     {"Freeze"},
 		"event_description": {"No ops"},
 		"start_time":        {"08:00"},
 		"end_time":          {"20:00"},
-		"rules_json":        {""},
+		formKeyRulesJSON:    {""},
 	}
 	r := makeFormRequest(form)
 	_, err := formToAppConfig(r)
@@ -133,11 +139,51 @@ func TestFormToAppConfig_MissingRules(t *testing.T) {
 	}
 }
 
+func TestFormToAppConfig_AllDay(t *testing.T) {
+	rules := []formRule{
+		{Anchor: ruleAnchorToday, Conditions: []string{"isTheFirstBusinessDayOfTheMonth"}},
+	}
+	form := url.Values{
+		formKeyLookback:     {"20"},
+		formKeyLookahead:    {"60"},
+		"country_code":      {countryCodeJPN},
+		"write_calendar_id": {"team-cal@group.calendar.google.com"},
+		"event_summary":     {"🚫 Freeze"},
+		"event_description": {"No prod."},
+		"all_day":           {"on"},
+		// start_time / end_time intentionally omitted (hidden when all_day checked)
+		formKeyRulesJSON: {rulesJSON(t, rules)},
+	}
+	r := makeFormRequest(form)
+
+	cfg, err := formToAppConfig(r)
+	if err != nil {
+		t.Fatalf("formToAppConfig() error = %v", err)
+	}
+
+	d := cfg.WriteTo.GoogleCalendar.IfTodayIsFreezeDay.Default
+	if d.AllDay == nil || !*d.AllDay {
+		t.Error("AllDay should be true")
+	}
+	// StartTime and EndTime should remain nil (not set by SetDefault when allDay=true).
+	if d.StartTime != nil {
+		t.Errorf("StartTime should be nil for all-day, got %q", *d.StartTime)
+	}
+	if d.EndTime != nil {
+		t.Errorf("EndTime should be nil for all-day, got %q", *d.EndTime)
+	}
+
+	// Should validate without error
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestFormToAppConfig_InvalidLookback(t *testing.T) {
 	form := url.Values{
-		"lookback_days":  {"notanumber"},
-		"lookahead_days": {"60"},
-		"rules_json":     {`[{"anchor":"today","conditions":["isNonBusinessDay"]}]`},
+		formKeyLookback:  {"notanumber"},
+		formKeyLookahead: {"60"},
+		formKeyRulesJSON: {`[{"anchor":"today","conditions":["isNonBusinessDay"]}]`},
 	}
 	r := makeFormRequest(form)
 	_, err := formToAppConfig(r)

--- a/internal/web/handler/dashboard.go
+++ b/internal/web/handler/dashboard.go
@@ -205,8 +205,7 @@ func dashboardPageHTML(basePath string, greeting string, rows []dashRow, allUser
 			if calDisplay == "" {
 				calDisplay = r.CalendarID
 			}
-			meta := fmt.Sprintf(`schema: <strong>%s</strong> &nbsp;·&nbsp; by: %s &nbsp;·&nbsp; 📅 %s`,
-				html.EscapeString(r.Schema),
+			meta := fmt.Sprintf(`by: %s &nbsp;·&nbsp; 📅 %s`,
 				html.EscapeString(trunc(r.Author, 40)),
 				html.EscapeString(trunc(calDisplay, 50)),
 			)


### PR DESCRIPTION
## Summary

- **Structured form replaces raw YAML editor** on `/configs/new` and `/configs/{id}/edit`: users fill named inputs instead of writing YAML by hand
- **Human-readable detail cards** replace the CodeMirror YAML viewer on `/configs/{id}`: shows date range, country, freeze rules, calendar ID, and event details as labelled fields
- **YAML stays as internal format**: `Config.ToYAML()` marshals the struct server-side after form submission

## What was removed

- CodeMirror dependency (all `<script>`/`<link>` tags for CodeMirror 5.65.16) from both form and detail pages
- `calendarOptions()` function that patched raw YAML text with regex — replaced with `calendarPickerHTML()` that fills the `write_calendar_id` input directly
- `config_yaml` hidden textarea approach

## What was added

### `internal/config/config.go`
- `Config.ToYAML() (string, error)` — marshal Config struct back to YAML via `gopkg.in/yaml.v3`
- `omitempty` tags on `DefaultConfig` pointer fields

### `internal/web/handler/config.go`
- `configFormData` struct — typed container for structured form fields
- `formToAppConfig(r *http.Request) (*appconfig.Config, error)` — parses structured POST → `Config`
- `formDataFromRequest()` / `configToFormData()` — helpers for error re-render and edit pre-fill
- `defaultFormData()` — sane defaults for new config form
- `calendarPickerHTML()` — calendar dropdown that fills the ID text input directly
- `configFormHTML()` — new structured form with OR/AND JS rules builder (no CodeMirror)
- `configDetailHTML()` — human-readable cards via `configDetailCardsHTML()`
- `conditionLabel()` / `countryLabel()` — display name helpers

### Tests
- `internal/config/config_test.go`: `TestToYAML_RoundTrip`, `TestToYAML_ContainsExpectedFields`
- `internal/web/handler/config_form_test.go`: `TestFormToAppConfig_ValidInput`, `TestFormToAppConfig_RoundTrip`, `TestFormToAppConfig_MissingRules`, `TestFormToAppConfig_InvalidLookback`

## Test plan

- [ ] `go test ./...` passes (all 6 new tests green)
- [ ] `golangci-lint run ./...` → 0 issues
- [ ] `gofmt -l .` → no output
- [ ] Create new config via form → redirects to detail, detail shows human-readable cards
- [ ] Edit existing config → form pre-populated from parsed YAML
- [ ] Calendar picker fills the ID field (not YAML)
- [ ] OR/AND rule builder: add/remove groups and conditions
- [ ] Form validation errors re-render the form with error message


Made with [Cursor](https://cursor.com)